### PR TITLE
add dps to form-action csp directive

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -37,7 +37,12 @@ export default function setUpWebSecurity(): Router {
       contentSecurityPolicy: {
         directives: {
           defaultSrc: ["'self'"],
-          formAction: ["'self'", new URL(config.apis.hmppsAuth.url).hostname, new URL(config.learningPlanUrl).hostname],
+          formAction: [
+            "'self'",
+            new URL(config.apis.hmppsAuth.url).hostname,
+            new URL(config.learningPlanUrl).hostname,
+            new URL(config.dpsHomeUrl).hostname,
+          ],
           // Hash allows inline script pulled in from https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/template.njk
           scriptSrc,
           styleSrc,


### PR DESCRIPTION
To enable prisoner search to be submitted from the global header