### PR TITLE
RR-397 - Added support for feature toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,10 @@ Or run tests with the cypress UI:
 The template project has implemented some scheduled checks to ensure that key dependencies are kept up to date.
 If these are not desired in the cloned project, remove references to `check_outdated` job from `.circleci/config.yml`
 
+
+## Feature Toggles
+Features can be toggled by setting the relevant environment variable.
+
+| Name                | Default Value | Type    | Description                                         |
+|---------------------|---------------|---------|-----------------------------------------------------|
+| SOME_TOGGLE_ENABLED | false         | Boolean | Example feature toggle, for demonstration purposes. |

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,5 +1,9 @@
 const production = process.env.NODE_ENV === 'production'
 
+const toBoolean = (value: unknown): boolean => {
+  return value === 'true'
+}
+
 function get<T>(name: string, fallback: T, options = { requireInProduction: false }): T | string {
   if (process.env[name]) {
     return process.env[name]
@@ -178,4 +182,7 @@ export default {
   isBeta: get('IS_BETA', 'false'),
   betaHelpUrl: get('BETA_HELP_URL', ''),
   betaFeedbackUrl: get('BETA_FEEDBACK_URL', ''),
+  featureToggles: {
+    someToggleEnabled: toBoolean(get('SOME_TOGGLE_ENABLED', false)),
+  },
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -75,4 +75,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('phaseName', config.phaseName)
   njkEnv.addGlobal('encryptUrlParameter', encryptUrlParameter)
   njkEnv.addGlobal('decryptUrlParameter', decryptUrlParameter)
+  njkEnv.addGlobal('featureToggles', config.featureToggles)
 }


### PR DESCRIPTION
This PR adds support for feature toggles in the same way that we have already done in the PLP UI codebase.

Now that we are in production there are some future planned features and changes whose rollout will need to be carefully managed (for example there are changes that will be rolled out into production at the same time as corresponding changes in the PLP UI). Features/changes of this nature can be sat behind a feature toggle, and enabled on an environment by environment basis.

