### PR TITLE
RR-538 - Update modsec config

### DIFF
--- a/helm_deploy/hmpps-ciag-careers-induction-ui/values.yaml
+++ b/helm_deploy/hmpps-ciag-careers-induction-ui/values.yaml
@@ -13,10 +13,14 @@ generic-service:
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-ciag-careers-induction-ui-cert
     modsecurity_enabled: true # enable OWASP core rules. Handle any false positives by removing or tweaking rules in modsecurity_snippet.
-    modsecurity_github_team: farsight-devs
     modsecurity_snippet: |
       SecRuleEngine On
-      # update OWASP rule 942440 (SQL Comment injection via ==) to not apply it to the connect.sid cookie (express) or the _csrf token. Both can legitimately include ==
+      # GitHub team name to grant access to the OpenSearch logs to be able to delve into the detail and cause
+      SecDefaultAction "phase:2,pass,log,tag:github_team=farsight-devs"
+      # Change default response code to be a 406 so that we can tell easily that it is modsecurity doing the blocking
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      # Update OWASP rule 942440 (SQL Comment injection via ==) to not apply it to the connect.sid cookie (express) or the _csrf token. Both can legitimately include ==
       SecRuleUpdateTargetById 942440 "!REQUEST_COOKIES:/connect.sid/" 
       SecRuleUpdateTargetById 942440 "!ARGS:_csrf"
 


### PR DESCRIPTION
This PR (hopefully) fixes the modsec config so that:
a) Our GH team (farsight-devs) have access to read the logs
b) the response codes are 406

It seems that this functionality regressed when I added the `modsecurity_snippet` in my last PR, and that (based on what other projects are doing) if you dont specify a `modsecurity_snippet` you get all this functionality for free, but if you do specify one you need to specify everything in it!

Doh!