### PR TITLE
RR-540 - Update dependencies in helm chart

### DIFF
--- a/helm_deploy/hmpps-ciag-careers-induction-ui/Chart.yaml
+++ b/helm_deploy/hmpps-ciag-careers-induction-ui/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-ciag-careers-induction-ui
 version: 1.0.0
 dependencies:
   - name: generic-service
-    version: 2.8.1
+    version: 2.9.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3


### PR DESCRIPTION
This PR bumps the version of the dependencies in the helm chart to the latest versions:

```
➜  hmpps-education-and-work-plan-ui git:(main) helm search repo hmpps-helm-charts
NAME                                                    CHART VERSION   APP VERSION     DESCRIPTION                                       
hmpps-helm-charts/clamav                                0.1.7           1.0             A Helm chart for Kubernetes                       
hmpps-helm-charts/generic-data-analytics-extractor      1.1.1                           Runs a daily cron job which extracts and sends ...
hmpps-helm-charts/generic-prometheus-alerts             1.3.3           1.0.0           Creates a set of standard prometheus alert rule...
hmpps-helm-charts/generic-service                       2.9.0                           A Helm chart for a generic application deployment.

```

(We only use 2 of the published charts from the above list, and only generic-service needs updating)