### PR TITLE
RR-570 - Refactor restClient to legacyRestClient

### DIFF
--- a/server/data/ciagApi/ciagApiClient.test.ts
+++ b/server/data/ciagApi/ciagApiClient.test.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import CiagApiClient from './ciagApiClient'
-import RestClient from '../restClient'
+import LegacyRestClient from '../legacyRestClient'
 
 // Mock the RestClient module
-jest.mock('../restClient')
+jest.mock('../legacyRestClient')
 
 describe('CiagApiClient', () => {
   let ciagApiClient: CiagApiClient
-  let restClientMock: jest.Mocked<RestClient>
+  let restClientMock: jest.Mocked<LegacyRestClient>
 
   beforeEach(() => {
-    restClientMock = new RestClient('mock_name', {} as any, 'mock_token') as jest.Mocked<RestClient>
+    restClientMock = new LegacyRestClient('mock_name', {} as any, 'mock_token') as jest.Mocked<LegacyRestClient>
     ciagApiClient = new CiagApiClient('dummyToken')
     ciagApiClient.restClient = restClientMock
   })

--- a/server/data/ciagApi/ciagApiClient.ts
+++ b/server/data/ciagApi/ciagApiClient.ts
@@ -1,5 +1,5 @@
 import config from '../../config'
-import RestClient from '../restClient'
+import LegacyRestClient from '../legacyRestClient'
 import CiagPlan from './interfaces/ciagPlan'
 import CreateCiagPlanArgs from './interfaces/createCiagPlanArgs'
 import CreateCiagPlanRequest from './models/createCiagPlanRequest'
@@ -7,10 +7,10 @@ import UpdateCiagPlanRequest from './models/updateCiagPlanRequest'
 
 const BASE_URL = '/ciag/induction'
 export default class CiagApiClient {
-  restClient: RestClient
+  restClient: LegacyRestClient
 
   constructor(token: string) {
-    this.restClient = new RestClient('Ciag Plan API', config.apis.educationAndWorkPlanApi, token)
+    this.restClient = new LegacyRestClient('Ciag Plan API', config.apis.educationAndWorkPlanApi, token)
   }
 
   async getCiagPlan(offenderId: string) {

--- a/server/data/componentsApi/componentsApiClient.test.ts
+++ b/server/data/componentsApi/componentsApiClient.test.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import ComponentsApiClient from './componentsApiClient'
-import RestClient from '../restClient'
+import LegacyRestClient from '../legacyRestClient'
 
 // Mock the RestClient module
-jest.mock('../restClient')
+jest.mock('../legacyRestClient')
 
 describe('ComponentsApiClient', () => {
   let componentsApiClient: ComponentsApiClient
-  let restClientMock: jest.Mocked<RestClient>
+  let restClientMock: jest.Mocked<LegacyRestClient>
 
   beforeEach(() => {
-    restClientMock = new RestClient('mock_name', {} as any, 'mock_token') as jest.Mocked<RestClient>
+    restClientMock = new LegacyRestClient('mock_name', {} as any, 'mock_token') as jest.Mocked<LegacyRestClient>
     componentsApiClient = new ComponentsApiClient('dummyToken')
     componentsApiClient.restClient = restClientMock
   })

--- a/server/data/componentsApi/componentsApiClient.ts
+++ b/server/data/componentsApi/componentsApiClient.ts
@@ -1,15 +1,15 @@
 import config from '../../config'
-import RestClient from '../restClient'
+import LegacyRestClient from '../legacyRestClient'
 import Component from './interfaces/component'
 import AvailableComponent from './types/availableComponents'
 
 export default class ComponentsApiClient {
-  restClient: RestClient
+  restClient: LegacyRestClient
 
   userToken: string
 
   constructor(token: string) {
-    this.restClient = new RestClient('Frontend components API', config.apis.frontendComponents, token)
+    this.restClient = new LegacyRestClient('Frontend components API', config.apis.frontendComponents, token)
     this.userToken = token
   }
 

--- a/server/data/legacyRestClient.ts
+++ b/server/data/legacyRestClient.ts
@@ -1,0 +1,159 @@
+import superagent, { SuperAgentRequest } from 'superagent'
+import Agent, { HttpsAgent } from 'agentkeepalive'
+import { Readable } from 'stream'
+
+import logger from '../log'
+import type { UnsanitisedError } from '../sanitisedError'
+import sanitiseError from '../sanitisedError'
+import { ApiConfig } from '../config'
+
+interface PutPostRequest {
+  path?: string
+  headers?: Record<string, string>
+  responseType?: string
+  data?: unknown
+}
+
+interface GetDeleteRequest {
+  path?: string
+  query?: string
+  headers?: Record<string, string>
+  responseType?: string
+}
+
+interface StreamRequest {
+  path?: string
+  headers?: Record<string, string>
+  errorLogger?: (e: UnsanitisedError) => void
+}
+
+/**
+ * @deprecated This class has been deprecated, and [RestClient] should be used instead for all new code.
+ *
+ * All code currently using this class will be migrated to [RestClient] in due course, and this class will be
+ * removed from the codebase.
+ */
+export default class LegacyRestClient {
+  agent: Agent
+
+  constructor(private readonly name: string, private readonly config: ApiConfig, private readonly token: string) {
+    this.agent = config.url.startsWith('https') ? new HttpsAgent(config.agent) : new Agent(config.agent)
+  }
+
+  private apiUrl() {
+    return this.config.url
+  }
+
+  private timeoutConfig() {
+    return this.config.timeout
+  }
+
+  defaultErrorLogger(error: UnsanitisedError): void {
+    logger.warn(sanitiseError(error), `Error calling ${this.name}`)
+  }
+
+  async get<T>({ path = null, query = '', headers = {}, responseType = '' }: GetDeleteRequest = {}): Promise<T> {
+    logger.info(`Get using user credentials: calling ${this.name}: ${path} ${query}`)
+    return this.getOrDelete('GET', superagent.get, { path, query, headers, responseType })
+  }
+
+  async put<T>({ path = null, headers = {}, responseType = '', data = {} }: PutPostRequest = {}): Promise<T> {
+    logger.info(`Put using user credentials: calling ${this.name}: ${path}`)
+    return this.putOrPost('PUT', superagent.put, { path, headers, responseType, data })
+  }
+
+  async post<T>({ path = null, headers = {}, responseType = '', data = {} }: PutPostRequest = {}): Promise<T> {
+    logger.info(`Post using user credentials: calling ${this.name}: ${path}`)
+    return this.putOrPost('POST', superagent.post, { path, headers, responseType, data })
+  }
+
+  async delete<T>({ path = null, query = '', headers = {}, responseType = '' }: GetDeleteRequest = {}): Promise<T> {
+    logger.info(`Get using user credentials: calling ${this.name}: ${path} ${query}`)
+    return this.getOrDelete('DELETE', superagent.delete, { path, headers, responseType })
+  }
+
+  private async putOrPost<T>(
+    verb: string,
+    method: (url: string) => SuperAgentRequest,
+    { path = null, headers = {}, responseType = '', data = {} } = {},
+  ): Promise<T> {
+    try {
+      const result = await method(`${this.apiUrl()}${path}`)
+        .send(data)
+        .agent(this.agent)
+        .retry(2, (err, res) => {
+          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
+          return undefined // retry handler only for logging retries, not to influence retry logic
+        })
+        .auth(this.token, { type: 'bearer' })
+        .set(headers)
+        .responseType(responseType)
+        .timeout(this.timeoutConfig())
+
+      return result.body
+    } catch (error) {
+      const sanitisedError = sanitiseError(error)
+      logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: '${verb}'`)
+      throw sanitisedError
+    }
+  }
+
+  async getOrDelete<T>(
+    verb: string,
+    method: (url: string) => SuperAgentRequest,
+    { path = null, query = '', headers = {}, responseType = '' } = {},
+  ): Promise<T> {
+    try {
+      const result = await method(`${this.apiUrl()}${path}`)
+        .agent(this.agent)
+        .retry(2, (err, res) => {
+          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
+          return undefined // retry handler only for logging retries, not to influence retry logic
+        })
+        .query(query)
+        .auth(this.token, { type: 'bearer' })
+        .set(headers)
+        .responseType(responseType)
+        .timeout(this.timeoutConfig())
+
+      return result.body
+    } catch (error) {
+      const sanitisedError = sanitiseError(error)
+      logger.warn({ ...sanitisedError, query }, `Error calling ${this.name}, path: '${path}', verb: '${verb}'`)
+      throw sanitisedError
+    }
+  }
+
+  async stream({
+    path = null,
+    headers = {},
+    errorLogger = this.defaultErrorLogger,
+  }: StreamRequest = {}): Promise<Readable> {
+    logger.info(`Get using user credentials: calling ${this.name}: ${path}`)
+    return new Promise((resolve, reject) => {
+      superagent
+        .get(`${this.apiUrl()}${path}`)
+        .agent(this.agent)
+        .auth(this.token, { type: 'bearer' })
+        .retry(2, (err, res) => {
+          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
+          return undefined // retry handler only for logging retries, not to influence retry logic
+        })
+        .timeout(this.timeoutConfig())
+        .set(headers)
+        .end((error, response) => {
+          if (error) {
+            errorLogger(error)
+            reject(error)
+          } else if (response) {
+            const s = new Readable()
+            // eslint-disable-next-line no-underscore-dangle,@typescript-eslint/no-empty-function
+            s._read = () => {}
+            s.push(response.body)
+            s.push(null)
+            resolve(s)
+          }
+        })
+    })
+  }
+}

--- a/server/data/manageUsersApi/manageUsersApiClient.test.ts
+++ b/server/data/manageUsersApi/manageUsersApiClient.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import RestClient from '../restClient'
+import LegacyRestClient from '../legacyRestClient'
 import config from '../../config'
 import ManageUsersApiClient from './manageUsersApiClient'
 
@@ -7,15 +7,19 @@ const user = {
   username: 'MOCK_NAME',
 }
 
-jest.mock('../restClient')
+jest.mock('../legacyRestClient')
 
 describe('ManageUsersApiClient', () => {
   let manageUsersApiClientMock: ManageUsersApiClient
-  let restClientMock: jest.Mocked<RestClient>
+  let restClientMock: jest.Mocked<LegacyRestClient>
 
   beforeEach(() => {
-    restClientMock = new RestClient('Manage Users Api', config.apis.manageUsersApi, 'token') as jest.Mocked<RestClient>
-    ;(RestClient as any).mockImplementation(() => restClientMock)
+    restClientMock = new LegacyRestClient(
+      'Manage Users Api',
+      config.apis.manageUsersApi,
+      'token',
+    ) as jest.Mocked<LegacyRestClient>
+    ;(LegacyRestClient as any).mockImplementation(() => restClientMock)
 
     manageUsersApiClientMock = new ManageUsersApiClient()
 

--- a/server/data/manageUsersApi/manageUsersApiClient.ts
+++ b/server/data/manageUsersApi/manageUsersApiClient.ts
@@ -1,5 +1,5 @@
 import config from '../../config'
-import RestClient from '../restClient'
+import LegacyRestClient from '../legacyRestClient'
 import logger from '../../../logger'
 
 export interface User {
@@ -12,8 +12,8 @@ export interface UserRole {
 }
 
 export default class ManageUsersApiClient {
-  private static restClient(token: string): RestClient {
-    return new RestClient('Manage users API', config.apis.manageUsersApi, token)
+  private static restClient(token: string): LegacyRestClient {
+    return new LegacyRestClient('Manage users API', config.apis.manageUsersApi, token)
   }
 
   getUser(token: string): Promise<User> {

--- a/server/data/nomisUserRolesApi/nomisUserRolesApiClient.test.ts
+++ b/server/data/nomisUserRolesApi/nomisUserRolesApiClient.test.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import NomisUserRolesApiClient from './nomisUserRolesApiClient'
-import RestClient from '../restClient'
+import LegacyRestClient from '../legacyRestClient'
 import config from '../../config'
 
-jest.mock('../restClient')
+jest.mock('../legacyRestClient')
 
 describe('NomisUserRolesApiClient', () => {
   let client: NomisUserRolesApiClient
-  let restClientMock: jest.Mocked<RestClient>
+  let restClientMock: jest.Mocked<LegacyRestClient>
 
   const staffId = 12345
 
@@ -16,12 +16,12 @@ describe('NomisUserRolesApiClient', () => {
   }
 
   beforeEach(() => {
-    restClientMock = new RestClient(
+    restClientMock = new LegacyRestClient(
       'Nomis User Roles API',
       config.apis.nomisUserRolesApi,
       'token',
-    ) as jest.Mocked<RestClient>
-    ;(RestClient as any).mockImplementation(() => restClientMock)
+    ) as jest.Mocked<LegacyRestClient>
+    ;(LegacyRestClient as any).mockImplementation(() => restClientMock)
     client = new NomisUserRolesApiClient('token')
 
     jest.clearAllMocks()

--- a/server/data/nomisUserRolesApi/nomisUserRolesApiClient.ts
+++ b/server/data/nomisUserRolesApi/nomisUserRolesApiClient.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import config from '../../config'
-import RestClient from '../restClient'
+import LegacyRestClient from '../legacyRestClient'
 import { UserDetails } from '../../services/userService'
 import GetStaffDetailsResponse from './getStaffDetailsResponse'
 
@@ -18,10 +18,10 @@ interface Role {
 }
 
 export default class NomisUserRolesApiClient {
-  restClient: RestClient
+  restClient: LegacyRestClient
 
   constructor(token: string) {
-    this.restClient = new RestClient('Nomis User Roles API', config.apis.nomisUserRolesApi, token)
+    this.restClient = new LegacyRestClient('Nomis User Roles API', config.apis.nomisUserRolesApi, token)
   }
 
   async getUserCaseLoads(user: UserDetails): Promise<string[]> {

--- a/server/data/prisonerSearch/prisonerSearchClient.test.ts
+++ b/server/data/prisonerSearch/prisonerSearchClient.test.ts
@@ -1,18 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import PrisonerSearchClient from './prisonerSearchClient'
-import RestClient from '../restClient'
+import LegacyRestClient from '../legacyRestClient'
 import config from '../../config'
 
-jest.mock('../restClient')
+jest.mock('../legacyRestClient')
 
 describe('PrisonerSearchClient', () => {
   let client: PrisonerSearchClient
-  let restClientMock: jest.Mocked<RestClient>
+  let restClientMock: jest.Mocked<LegacyRestClient>
   const offenderNo = 'A1234BC'
 
   beforeEach(() => {
-    restClientMock = new RestClient('Prisoner Search', config.apis.prisonerSearch, 'token') as jest.Mocked<RestClient>
-    ;(RestClient as any).mockImplementation(() => restClientMock)
+    restClientMock = new LegacyRestClient(
+      'Prisoner Search',
+      config.apis.prisonerSearch,
+      'token',
+    ) as jest.Mocked<LegacyRestClient>
+    ;(LegacyRestClient as any).mockImplementation(() => restClientMock)
     client = new PrisonerSearchClient('token')
   })
 

--- a/server/data/prisonerSearch/prisonerSearchClient.ts
+++ b/server/data/prisonerSearch/prisonerSearchClient.ts
@@ -1,17 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import config from '../../config'
-import RestClient from '../restClient'
+import LegacyRestClient from '../legacyRestClient'
 import GetPrisonerByIdResult from './getPrisonerByIdResult'
 
 const GET_PRISONER_BY_ID_PATH = '/prisoner'
 
 export default class PrisonerSearchClient {
-  restClient: RestClient
+  restClient: LegacyRestClient
 
   newToken: string
 
   constructor(token: string) {
-    this.restClient = new RestClient('Prisoner Search', config.apis.prisonerSearch, token)
+    this.restClient = new LegacyRestClient('Prisoner Search', config.apis.prisonerSearch, token)
   }
 
   async getPrisonerById(id: string): Promise<GetPrisonerByIdResult> {


### PR DESCRIPTION
This PR renames the previous `restClient` to `legacyRestClient`; and introduces (a better 😁 ) `restClient` copied verbatim from PLP UI

Why?
Good question. 
Typescript apps built from the dps bootstrap come with a `restClient` class from the bootstrap template. Both the CIAG UI and PLP UI have modified their versions of `restClient`, but modified them differently. The modifications to the CIAG UI one (the one that is being deprecated in this PR) seem to be around the signatures of the get/put/post/delete methods. The modifications in the PLP UI version are around logging and error handling.
RR-570 is about making the CIAG UI call the new Inductions API to get the Induction. This work has already been done in the PLP UI, and my plan is to verbatim copy and paste many of the classes etc. These classes will make use of `restClient`, and the version in the CIAG UI is incompatible with the PLP UI client and service class code (because of the changes to the signatures)

I had some choices:
1. Update the code I'm going to copy from PLP to use the CIAG UI version of `restClient`
Not keen, mainly because I think the PLP UI version of `restClient` is better, plus I'd like both UI codebases to be as consistent as possible in respect of patterns etc - we might merge them into 1 at some point perhaps?
2. Replace the CIAG UI `restClient` with the PLP one, and refactor all the CIAG classes that use it to use the new `restClient`
Longer term thats perhaps where we'll end up, but at this stage I don't want a massive and risky change. I want to change as little as possible, and keep it within the scope of the ticket.
3. Rename the CIAG UI version of `restClient` and deprecate it; and introduce the PLP UI version to sit parallel
That's the approach I've gone with, and is essentially what this PR is about