### PR TITLE
RR-596 - Create Induction client method

### DIFF
--- a/server/@types/educationAndWorkPlanApiClient/index.d.ts
+++ b/server/@types/educationAndWorkPlanApiClient/index.d.ts
@@ -9,4 +9,13 @@ declare module 'educationAndWorkPlanApiClient' {
   export type InPrisonWorkInterest = components['schemas']['InPrisonWorkInterest']
   export type AchievedQualification = components['schemas']['AchievedQualification']
   export type InPrisonTrainingInterest = components['schemas']['InPrisonTrainingInterest']
+
+  export type CreateInductionRequest = components['schemas']['CreateInductionRequest']
+  export type CreateWorkOnReleaseRequest = components['schemas']['CreateWorkOnReleaseRequest']
+  export type CreatePreviousQualificationsRequest = components['schemas']['CreatePreviousQualificationsRequest']
+  export type CreatePreviousTrainingRequest = components['schemas']['CreatePreviousTrainingRequest']
+  export type CreatePreviousWorkExperiencesRequest = components['schemas']['CreatePreviousWorkExperiencesRequest']
+  export type CreateInPrisonInterestsRequest = components['schemas']['CreateInPrisonInterestsRequest']
+  export type CreatePersonalSkillsAndInterestsRequest = components['schemas']['CreatePersonalSkillsAndInterestsRequest']
+  export type CreateFutureWorkInterestsRequest = components['schemas']['CreateFutureWorkInterestsRequest']
 }

--- a/server/data/educationAndWorkPlanClient.test.ts
+++ b/server/data/educationAndWorkPlanClient.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import config from '../config'
 import EducationAndWorkPlanClient from './educationAndWorkPlanClient'
 import { aShortQuestionSetInduction } from '../testsupport/inductionResponseTestDataBuilder'
+import { aValidCreateInductionRequestForPrisonerHopingToWork } from '../testsupport/createInductionRequestTestDataBuilder'
 
 describe('educationAndWorkPlanClient', () => {
   const educationAndWorkPlanClient = new EducationAndWorkPlanClient()
@@ -75,6 +76,45 @@ describe('educationAndWorkPlanClient', () => {
         // Then
         expect(nock.isDone()).toBe(true)
         expect(e.status).toEqual(404)
+        expect(e.data).toEqual(expectedResponseBody)
+      }
+    })
+  })
+
+  describe('createInduction', () => {
+    it('should create Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+      const createRequest = aValidCreateInductionRequestForPrisonerHopingToWork()
+      educationAndWorkPlanApi.post(`/inductions/${prisonNumber}`, createRequest).reply(201)
+
+      // When
+      await educationAndWorkPlanClient.createInduction(prisonNumber, createRequest, systemToken)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it('should not create Induction given API returns error response', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+      const createRequest = aValidCreateInductionRequestForPrisonerHopingToWork()
+      const expectedResponseBody = {
+        status: 500,
+        userMessage: 'An unexpected error occurred',
+        developerMessage: 'An unexpected error occurred',
+      }
+      educationAndWorkPlanApi.post(`/inductions/${prisonNumber}`, createRequest).reply(500, expectedResponseBody)
+
+      // When
+      try {
+        await educationAndWorkPlanClient.createInduction(prisonNumber, createRequest, systemToken)
+      } catch (e) {
+        // Then
+        expect(nock.isDone()).toBe(true)
+        expect(e.status).toEqual(500)
         expect(e.data).toEqual(expectedResponseBody)
       }
     })

--- a/server/data/educationAndWorkPlanClient.ts
+++ b/server/data/educationAndWorkPlanClient.ts
@@ -1,10 +1,17 @@
-import type { InductionResponse } from 'educationAndWorkPlanApiClient'
+import type { CreateInductionRequest, InductionResponse } from 'educationAndWorkPlanApiClient'
 import RestClient from './restClient'
 import config from '../config'
 
 export default class EducationAndWorkPlanClient {
   private static restClient(token: string): RestClient {
     return new RestClient('Education and Work Plan API Client', config.apis.educationAndWorkPlanApi, token)
+  }
+
+  async createInduction(prisonNumber: string, createRequest: CreateInductionRequest, token: string): Promise<unknown> {
+    return EducationAndWorkPlanClient.restClient(token).post({
+      path: `/inductions/${prisonNumber}`,
+      data: createRequest,
+    })
   }
 
   async getInduction(prisonNumber: string, token: string): Promise<InductionResponse> {

--- a/server/testsupport/createInductionRequestTestDataBuilder.ts
+++ b/server/testsupport/createInductionRequestTestDataBuilder.ts
@@ -1,0 +1,113 @@
+import type { CreateInductionRequest } from 'educationAndWorkPlanApiClient'
+
+const aValidCreateInductionRequestForPrisonerHopingToWork = (): CreateInductionRequest => {
+  return {
+    prisonId: 'MDI',
+    workOnRelease: {
+      hopingToWork: 'YES',
+      affectAbilityToWork: ['NONE'],
+      affectAbilityToWorkOther: null,
+      notHopingToWorkReasons: null,
+      notHopingToWorkOtherReason: null,
+    },
+    previousWorkExperiences: {
+      hasWorkedBefore: true,
+      experiences: [
+        {
+          experienceType: 'CONSTRUCTION',
+          experienceTypeOther: null,
+          role: 'General labourer',
+          details: 'Groundwork and basic block work and bricklaying',
+        },
+        {
+          experienceType: 'OTHER',
+          experienceTypeOther: 'Retail delivery',
+          role: 'Milkman',
+          details: 'Self employed franchise operator delivering milk and associated diary products.',
+        },
+      ],
+    },
+    futureWorkInterests: {
+      interests: [
+        {
+          workType: 'RETAIL',
+          workTypeOther: null,
+          role: null,
+        },
+        {
+          workType: 'CONSTRUCTION',
+          workTypeOther: null,
+          role: 'General labourer',
+        },
+        {
+          workType: 'OTHER',
+          workTypeOther: 'Film, TV and media',
+          role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+        },
+      ],
+    },
+    personalSkillsAndInterests: {
+      skills: [
+        { skillType: 'TEAMWORK', skillTypeOther: null },
+        { skillType: 'WILLINGNESS_TO_LEARN', skillTypeOther: null },
+        { skillType: 'OTHER', skillTypeOther: 'Tenacity' },
+      ],
+      interests: [
+        { interestType: 'CREATIVE', interestTypeOther: null },
+        { interestType: 'DIGITAL', interestTypeOther: null },
+        { interestType: 'OTHER', interestTypeOther: 'Renewable energy' },
+      ],
+    },
+    previousQualifications: {
+      educationLevel: 'SECONDARY_SCHOOL_TOOK_EXAMS',
+      qualifications: [
+        {
+          subject: 'Pottery',
+          grade: 'C',
+          level: 'LEVEL_4',
+        },
+      ],
+    },
+    previousTraining: {
+      trainingTypes: ['FIRST_AID_CERTIFICATE', 'MANUAL_HANDLING', 'OTHER'],
+      trainingTypeOther: 'Advanced origami',
+    },
+  }
+}
+
+const aValidCreateInductionRequestForPrisonerNotHopingToWork = (): CreateInductionRequest => {
+  return {
+    prisonId: 'MDI',
+    workOnRelease: {
+      hopingToWork: 'NO',
+      affectAbilityToWork: ['FULL_TIME_CARER'],
+      affectAbilityToWorkOther: null,
+      notHopingToWorkReasons: ['LACKS_CONFIDENCE_OR_MOTIVATION'],
+      notHopingToWorkOtherReason: null,
+    },
+    inPrisonInterests: {
+      inPrisonWorkInterests: {
+        workType: ['CLEANING_AND_HYGIENE'],
+      },
+      inPrisonTrainingInterests: {
+        trainingType: ['WOODWORK_AND_JOINERY'],
+      },
+    },
+    previousQualifications: {
+      educationLevel: null,
+      qualifications: [
+        {
+          subject: 'Pottery',
+          grade: 'C',
+          level: 'LEVEL_4',
+        },
+      ],
+    },
+    previousTraining: {
+      trainingTypes: ['FIRST_AID_CERTIFICATE', 'MANUAL_HANDLING', 'OTHER'],
+      trainingTypeOther: 'Advanced origami',
+    },
+  }
+}
+
+export { aValidCreateInductionRequestForPrisonerHopingToWork, aValidCreateInductionRequestForPrisonerNotHopingToWork }


### PR DESCRIPTION
This PR adds the required `createInduction()` to the `EducationAndWorkPlanClient` in order to create an Induction via the new `/inductions` API.