### PR TITLE
RR-574 - Introduce DTO, mapper and service class to return DTO

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -1,0 +1,217 @@
+declare module 'dto' {
+  /**
+   * Interface defining common reference and audit related properties that DTO types can inherit through extension.
+   */
+  interface ReferencedAndAuditable {
+    reference: string
+    createdBy: string
+    createdByDisplayName: string
+    createdAt: Date
+    createdAtPrison: string
+    updatedBy: string
+    updatedByDisplayName: string
+    updatedAt: Date
+    updatedAtPrison: string
+  }
+
+  export interface InductionDto extends ReferencedAndAuditable {
+    prisonNumber: string
+    workOnRelease: WorkOnReleaseDto
+    previousQualifications?: PreviousQualificationsDto
+    previousTraining?: PreviousTrainingDto
+    previousWorkExperiences?: PreviousWorkExperiencesDto
+    inPrisonInterests?: InPrisonInterestsDto
+    personalSkillsAndInterests?: PersonalSkillsAndInterestsDto
+    futureWorkInterests?: FutureWorkInterestsDto
+  }
+
+  export interface WorkOnReleaseDto extends ReferencedAndAuditable {
+    hopingToWork: 'YES' | 'NO' | 'NOT_SURE'
+    notHopingToWorkReasons: (
+      | 'LIMIT_THEIR_ABILITY'
+      | 'FULL_TIME_CARER'
+      | 'LACKS_CONFIDENCE_OR_MOTIVATION'
+      | 'HEALTH'
+      | 'RETIRED'
+      | 'NO_RIGHT_TO_WORK'
+      | 'NOT_SURE'
+      | 'OTHER'
+      | 'NO_REASON'
+    )[]
+    affectAbilityToWork: (
+      | 'CARING_RESPONSIBILITIES'
+      | 'LIMITED_BY_OFFENSE'
+      | 'HEALTH_ISSUES'
+      | 'NO_RIGHT_TO_WORK'
+      | 'OTHER'
+      | 'NONE'
+    )[]
+    notHopingToWorkOtherReason?: string
+    affectAbilityToWorkOther?: string
+  }
+
+  export interface PreviousQualificationsDto extends ReferencedAndAuditable {
+    educationLevel:
+      | 'PRIMARY_SCHOOL'
+      | 'SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS'
+      | 'SECONDARY_SCHOOL_TOOK_EXAMS'
+      | 'FURTHER_EDUCATION_COLLEGE'
+      | 'UNDERGRADUATE_DEGREE_AT_UNIVERSITY'
+      | 'POSTGRADUATE_DEGREE_AT_UNIVERSITY'
+      | 'NOT_SURE'
+    qualifications: Array<AchievedQualificationDto>
+  }
+
+  export interface PreviousTrainingDto extends ReferencedAndAuditable {
+    trainingTypes: (
+      | 'CSCS_CARD'
+      | 'FIRST_AID_CERTIFICATE'
+      | 'FOOD_HYGIENE_CERTIFICATE'
+      | 'FULL_UK_DRIVING_LICENCE'
+      | 'HEALTH_AND_SAFETY'
+      | 'HGV_LICENCE'
+      | 'MACHINERY_TICKETS'
+      | 'MANUAL_HANDLING'
+      | 'TRADE_COURSE'
+      | 'OTHER'
+      | 'NONE'
+    )[]
+    trainingTypeOther?: string
+  }
+
+  export interface PreviousWorkExperiencesDto extends ReferencedAndAuditable {
+    hasWorkedBefore: boolean
+    experiences: Array<PreviousWorkExperienceDto>
+  }
+
+  export interface InPrisonInterestsDto extends ReferencedAndAuditable {
+    inPrisonWorkInterests: Array<InPrisonWorkInterestDto>
+    inPrisonTrainingInterests: Array<InPrisonTrainingInterestDto>
+  }
+
+  export interface PersonalSkillsAndInterestsDto extends ReferencedAndAuditable {
+    skills: Array<PersonalSkillDto>
+    interests: Array<PersonalInterestDto>
+  }
+
+  export interface FutureWorkInterestsDto extends ReferencedAndAuditable {
+    interests: Array<FutureWorkInterestDto>
+  }
+
+  export interface AchievedQualificationDto {
+    subject: string
+    level: 'ENTRY_LEVEL' | 'LEVEL_1' | 'LEVEL_2' | 'LEVEL_3' | 'LEVEL_4' | 'LEVEL_5' | 'LEVEL_6' | 'LEVEL_7' | 'LEVEL_8'
+    grade: string
+  }
+
+  export interface PreviousWorkExperienceDto {
+    experienceType:
+      | 'OUTDOOR'
+      | 'CONSTRUCTION'
+      | 'DRIVING'
+      | 'BEAUTY'
+      | 'HOSPITALITY'
+      | 'TECHNICAL'
+      | 'MANUFACTURING'
+      | 'OFFICE'
+      | 'RETAIL'
+      | 'SPORTS'
+      | 'WAREHOUSING'
+      | 'WASTE_MANAGEMENT'
+      | 'EDUCATION_TRAINING'
+      | 'CLEANING_AND_MAINTENANCE'
+      | 'OTHER'
+    experienceTypeOther?: string
+    role?: string
+    details?: string
+  }
+
+  export interface InPrisonWorkInterestDto {
+    workType:
+      | 'CLEANING_AND_HYGIENE'
+      | 'COMPUTERS_OR_DESK_BASED'
+      | 'GARDENING_AND_OUTDOORS'
+      | 'KITCHENS_AND_COOKING'
+      | 'MAINTENANCE'
+      | 'PRISON_LAUNDRY'
+      | 'PRISON_LIBRARY'
+      | 'TEXTILES_AND_SEWING'
+      | 'WELDING_AND_METALWORK'
+      | 'WOODWORK_AND_JOINERY'
+      | 'OTHER'
+    workTypeOther?: string
+  }
+
+  export interface InPrisonTrainingInterestDto {
+    trainingType:
+      | 'BARBERING_AND_HAIRDRESSING'
+      | 'CATERING'
+      | 'COMMUNICATION_SKILLS'
+      | 'ENGLISH_LANGUAGE_SKILLS'
+      | 'FORKLIFT_DRIVING'
+      | 'INTERVIEW_SKILLS'
+      | 'MACHINERY_TICKETS'
+      | 'NUMERACY_SKILLS'
+      | 'RUNNING_A_BUSINESS'
+      | 'SOCIAL_AND_LIFE_SKILLS'
+      | 'WELDING_AND_METALWORK'
+      | 'WOODWORK_AND_JOINERY'
+      | 'OTHER'
+    trainingTypeOther?: string
+  }
+
+  export interface PersonalSkillDto {
+    skillType:
+      | 'COMMUNICATION'
+      | 'POSITIVE_ATTITUDE'
+      | 'RESILIENCE'
+      | 'SELF_MANAGEMENT'
+      | 'TEAMWORK'
+      | 'THINKING_AND_PROBLEM_SOLVING'
+      | 'WILLINGNESS_TO_LEARN'
+      | 'OTHER'
+      | 'NONE'
+    skillTypeOther?: string
+  }
+
+  export interface PersonalInterestDto {
+    interestType:
+      | 'COMMUNITY'
+      | 'CRAFTS'
+      | 'CREATIVE'
+      | 'DIGITAL'
+      | 'KNOWLEDGE_BASED'
+      | 'MUSICAL'
+      | 'OUTDOOR'
+      | 'NATURE_AND_ANIMALS'
+      | 'SOCIAL'
+      | 'SOLO_ACTIVITIES'
+      | 'SOLO_SPORTS'
+      | 'TEAM_SPORTS'
+      | 'WELLNESS'
+      | 'OTHER'
+      | 'NONE'
+    interestTypeOther?: string
+  }
+
+  export interface FutureWorkInterestDto {
+    workType:
+      | 'OUTDOOR'
+      | 'CONSTRUCTION'
+      | 'DRIVING'
+      | 'BEAUTY'
+      | 'HOSPITALITY'
+      | 'TECHNICAL'
+      | 'MANUFACTURING'
+      | 'OFFICE'
+      | 'RETAIL'
+      | 'SPORTS'
+      | 'WAREHOUSING'
+      | 'WASTE_MANAGEMENT'
+      | 'EDUCATION_TRAINING'
+      | 'CLEANING_AND_MAINTENANCE'
+      | 'OTHER'
+    workTypeOther?: string
+    role?: string
+  }
+}

--- a/server/data/mappers/inductionDtoMapper.test.ts
+++ b/server/data/mappers/inductionDtoMapper.test.ts
@@ -1,0 +1,35 @@
+import {
+  aLongQuestionSetInduction,
+  aShortQuestionSetInduction,
+} from '../../testsupport/inductionResponseTestDataBuilder'
+import {
+  aLongQuestionSetInductionDto,
+  aShortQuestionSetInductionDto,
+} from '../../testsupport/inductionDtoTestDataBuilder'
+import toInductionDto from './inductionDtoMapper'
+
+describe('inductionDtoMapper', () => {
+  it('should map to InductionDto given a short question set InductionResponse', () => {
+    // Given
+    const shortQuestionSetInductionResponse = aShortQuestionSetInduction()
+    const expected = aShortQuestionSetInductionDto()
+
+    // When
+    const actual = toInductionDto(shortQuestionSetInductionResponse)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  it('should map to InductionDto given a long question set InductionResponse', () => {
+    // Given
+    const longQuestionSetInductionResponse = aLongQuestionSetInduction()
+    const expected = aLongQuestionSetInductionDto()
+
+    // When
+    const actual = toInductionDto(longQuestionSetInductionResponse)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/data/mappers/inductionDtoMapper.ts
+++ b/server/data/mappers/inductionDtoMapper.ts
@@ -1,0 +1,60 @@
+import { parseISO } from 'date-fns'
+import type { InductionResponse } from 'educationAndWorkPlanApiClient'
+import type { InductionDto } from 'dto'
+
+const toInductionDto = (inductionResponse: InductionResponse): InductionDto => {
+  return {
+    ...inductionResponse,
+    createdAt: parseISO(inductionResponse.createdAt),
+    updatedAt: parseISO(inductionResponse.updatedAt),
+    workOnRelease: {
+      ...inductionResponse.workOnRelease,
+      createdAt: parseISO(inductionResponse.workOnRelease.createdAt),
+      updatedAt: parseISO(inductionResponse.workOnRelease.updatedAt),
+    },
+    previousQualifications: inductionResponse.previousQualifications
+      ? {
+          ...inductionResponse.previousQualifications,
+          createdAt: parseISO(inductionResponse.previousQualifications.createdAt),
+          updatedAt: parseISO(inductionResponse.previousQualifications.updatedAt),
+        }
+      : undefined,
+    previousTraining: inductionResponse.previousTraining
+      ? {
+          ...inductionResponse.previousTraining,
+          createdAt: parseISO(inductionResponse.previousTraining.createdAt),
+          updatedAt: parseISO(inductionResponse.previousTraining.updatedAt),
+        }
+      : undefined,
+    previousWorkExperiences: inductionResponse.previousWorkExperiences
+      ? {
+          ...inductionResponse.previousWorkExperiences,
+          createdAt: parseISO(inductionResponse.previousWorkExperiences.createdAt),
+          updatedAt: parseISO(inductionResponse.previousWorkExperiences.updatedAt),
+        }
+      : undefined,
+    inPrisonInterests: inductionResponse.inPrisonInterests
+      ? {
+          ...inductionResponse.inPrisonInterests,
+          createdAt: parseISO(inductionResponse.inPrisonInterests.createdAt),
+          updatedAt: parseISO(inductionResponse.inPrisonInterests.updatedAt),
+        }
+      : undefined,
+    personalSkillsAndInterests: inductionResponse.personalSkillsAndInterests
+      ? {
+          ...inductionResponse.personalSkillsAndInterests,
+          createdAt: parseISO(inductionResponse.personalSkillsAndInterests.createdAt),
+          updatedAt: parseISO(inductionResponse.personalSkillsAndInterests.updatedAt),
+        }
+      : undefined,
+    futureWorkInterests: inductionResponse.futureWorkInterests
+      ? {
+          ...inductionResponse.futureWorkInterests,
+          createdAt: parseISO(inductionResponse.futureWorkInterests.createdAt),
+          updatedAt: parseISO(inductionResponse.futureWorkInterests.updatedAt),
+        }
+      : undefined,
+  }
+}
+
+export default toInductionDto

--- a/server/services/inductionService.ts
+++ b/server/services/inductionService.ts
@@ -1,6 +1,7 @@
-import type { InductionResponse } from 'educationAndWorkPlanApiClient'
+import type { InductionDto } from 'dto'
 import logger from '../../logger'
 import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
+import toInductionDto from '../data/mappers/inductionDtoMapper'
 
 export default class InductionService {
   constructor(private readonly educationAndWorkPlanClient: EducationAndWorkPlanClient) {}
@@ -9,9 +10,10 @@ export default class InductionService {
     return (await this.getInduction(prisonNumber, token)) !== undefined
   }
 
-  private getInduction = async (prisonNumber: string, token: string): Promise<InductionResponse> => {
+  async getInduction(prisonNumber: string, token: string): Promise<InductionDto> {
     try {
-      return await this.educationAndWorkPlanClient.getInduction(prisonNumber, token)
+      const inductionResponse = await this.educationAndWorkPlanClient.getInduction(prisonNumber, token)
+      return toInductionDto(inductionResponse)
     } catch (error) {
       if (error.status === 404) {
         logger.info(`No Induction found for prisoner [${prisonNumber}] in Education And Work Plan API`)

--- a/server/testsupport/inductionDtoTestDataBuilder.ts
+++ b/server/testsupport/inductionDtoTestDataBuilder.ts
@@ -1,0 +1,218 @@
+import { parseISO } from 'date-fns'
+import type { InductionDto } from 'dto'
+
+const aLongQuestionSetInductionDto = (
+  options?: CoreBuilderOptions & {
+    hasWorkedBefore?: boolean
+    hasSkills?: boolean
+    hasInterests?: boolean
+  },
+): InductionDto => {
+  return {
+    ...baseInductionDtoTemplate(options),
+    workOnRelease: {
+      reference: 'bdebe39f-6f85-459b-81be-a26341c3fe3c',
+      ...auditFields(options),
+      hopingToWork: 'YES',
+      affectAbilityToWork: ['NONE'],
+      affectAbilityToWorkOther: null,
+      notHopingToWorkReasons: null,
+      notHopingToWorkOtherReason: null,
+    },
+    previousWorkExperiences: {
+      reference: 'bb45462e-8225-490d-8c1c-ad6692223d4d',
+      ...auditFields(options),
+      hasWorkedBefore:
+        !options || options.hasWorkedBefore === null || options.hasWorkedBefore === undefined
+          ? true
+          : options.hasWorkedBefore,
+      experiences:
+        !options ||
+        options.hasWorkedBefore === null ||
+        options.hasWorkedBefore === undefined ||
+        options.hasWorkedBefore === true
+          ? [
+              {
+                experienceType: 'CONSTRUCTION',
+                experienceTypeOther: null,
+                role: 'General labourer',
+                details: 'Groundwork and basic block work and bricklaying',
+              },
+              {
+                experienceType: 'OTHER',
+                experienceTypeOther: 'Retail delivery',
+                role: 'Milkman',
+                details: 'Self employed franchise operator delivering milk and associated diary products.',
+              },
+            ]
+          : [],
+    },
+    futureWorkInterests: {
+      reference: 'cad34670-691d-4862-8014-dc08a6f620b9',
+      ...auditFields(options),
+      interests: [
+        {
+          workType: 'RETAIL',
+          workTypeOther: null,
+          role: null,
+        },
+        {
+          workType: 'CONSTRUCTION',
+          workTypeOther: null,
+          role: 'General labourer',
+        },
+        {
+          workType: 'OTHER',
+          workTypeOther: 'Film, TV and media',
+          role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+        },
+      ],
+    },
+    personalSkillsAndInterests: {
+      reference: '517c470f-f9b5-4d49-9148-4458fe358439',
+      ...auditFields(options),
+      skills:
+        !options || options.hasSkills === null || options.hasSkills === undefined || options.hasSkills === true
+          ? [
+              { skillType: 'TEAMWORK', skillTypeOther: null },
+              { skillType: 'WILLINGNESS_TO_LEARN', skillTypeOther: null },
+              { skillType: 'OTHER', skillTypeOther: 'Tenacity' },
+            ]
+          : [],
+      interests:
+        !options || options.hasInterests === null || options.hasInterests === undefined || options.hasInterests === true
+          ? [
+              { interestType: 'CREATIVE', interestTypeOther: null },
+              { interestType: 'DIGITAL', interestTypeOther: null },
+              { interestType: 'OTHER', interestTypeOther: 'Renewable energy' },
+            ]
+          : [],
+    },
+    previousQualifications: {
+      reference: 'dea24acc-fde5-4ead-a9eb-e1757de2542c',
+      ...auditFields(options),
+      educationLevel: 'SECONDARY_SCHOOL_TOOK_EXAMS',
+      qualifications: [
+        {
+          subject: 'Pottery',
+          grade: 'C',
+          level: 'LEVEL_4',
+        },
+      ],
+    },
+    previousTraining: {
+      reference: 'a8e1fe50-1e3b-4784-a27f-ee1c54fc7616',
+      ...auditFields(options),
+      trainingTypes: ['FIRST_AID_CERTIFICATE', 'MANUAL_HANDLING', 'OTHER'],
+      trainingTypeOther: 'Advanced origami',
+    },
+  }
+}
+
+const aShortQuestionSetInductionDto = (
+  options?: CoreBuilderOptions & {
+    hopingToGetWork?: 'NO' | 'NOT_SURE'
+  },
+): InductionDto => {
+  return {
+    ...baseInductionDtoTemplate(options),
+    workOnRelease: {
+      reference: 'bdebe39f-6f85-459b-81be-a26341c3fe3c',
+      ...auditFields(options),
+      hopingToWork: options?.hopingToGetWork || 'NO',
+      affectAbilityToWork: null,
+      affectAbilityToWorkOther: null,
+      notHopingToWorkReasons: ['HEALTH', 'OTHER'],
+      notHopingToWorkOtherReason: 'Will be of retirement age at release',
+    },
+    inPrisonInterests: {
+      reference: 'ae6a6a94-df32-4a90-b39d-ff1a100a6da0',
+      ...auditFields(options),
+      inPrisonWorkInterests: [
+        { workType: 'CLEANING_AND_HYGIENE', workTypeOther: null },
+        { workType: 'OTHER', workTypeOther: 'Gardening and grounds keeping' },
+      ],
+      inPrisonTrainingInterests: [
+        { trainingType: 'FORKLIFT_DRIVING', trainingTypeOther: null },
+        { trainingType: 'CATERING', trainingTypeOther: null },
+        { trainingType: 'OTHER', trainingTypeOther: 'Advanced origami' },
+      ],
+    },
+    previousQualifications: {
+      reference: 'dea24acc-fde5-4ead-a9eb-e1757de2542c',
+      ...auditFields(options),
+      educationLevel: null,
+      qualifications: [
+        {
+          subject: 'English',
+          grade: 'C',
+          level: 'LEVEL_6',
+        },
+        {
+          subject: 'Maths',
+          grade: 'A*',
+          level: 'LEVEL_6',
+        },
+      ],
+    },
+    previousTraining: {
+      reference: 'a8e1fe50-1e3b-4784-a27f-ee1c54fc7616',
+      ...auditFields(options),
+      trainingTypes: ['FULL_UK_DRIVING_LICENCE', 'OTHER'],
+      trainingTypeOther: 'Beginners cookery for IT professionals',
+    },
+  }
+}
+
+type CoreBuilderOptions = {
+  prisonNumber?: string
+  createdBy?: string
+  createdByDisplayName?: string
+  createdAt?: Date
+  createdAtPrison?: string
+  updatedBy?: string
+  updatedByDisplayName?: string
+  updatedAt?: Date
+  updatedAtPrison?: string
+}
+
+const baseInductionDtoTemplate = (options?: CoreBuilderOptions): InductionDto => {
+  return {
+    reference: '814ade0a-a3b2-46a3-862f-79211ba13f7b',
+    prisonNumber: options?.prisonNumber || 'A1234BC',
+    ...auditFields(options),
+    workOnRelease: undefined,
+    previousQualifications: undefined,
+    previousTraining: undefined,
+    previousWorkExperiences: undefined,
+    inPrisonInterests: undefined,
+    personalSkillsAndInterests: undefined,
+    futureWorkInterests: undefined,
+  }
+}
+
+const auditFields = (
+  options?: CoreBuilderOptions,
+): {
+  createdBy: string
+  createdByDisplayName: string
+  createdAt: Date
+  createdAtPrison: string
+  updatedBy: string
+  updatedByDisplayName: string
+  updatedAt: Date
+  updatedAtPrison: string
+} => {
+  return {
+    createdBy: options?.createdByDisplayName || 'asmith_gen',
+    createdByDisplayName: options?.createdByDisplayName || 'Alex Smith',
+    createdAt: options?.createdAt || parseISO('2023-06-19T09:39:44Z'),
+    createdAtPrison: options?.createdAtPrison || 'MDI',
+    updatedBy: options?.updatedBy || 'asmith_gen',
+    updatedByDisplayName: options?.updatedByDisplayName || 'Alex Smith',
+    updatedAt: options?.updatedAt || parseISO('2023-06-19T09:39:44Z'),
+    updatedAtPrison: options?.updatedAtPrison || 'MDI',
+  }
+}
+
+export { aLongQuestionSetInductionDto, aShortQuestionSetInductionDto }


### PR DESCRIPTION
This PR introduces the `InductionDto`, the mapper to map to it from an `InductionResponse` (API class), and change the `InductionService` to return the DTO

The `InductionDto`is near identical to `InductionResponse` - the only difference is that the audit date fields (`createdAt` and `updatedAt` throughout are `Date`s rather than `string`s from the API