### PR TITLE
RR-570 - Add mapper to map from InductionDTO to CiagPlan

### DIFF
--- a/server/data/mappers/ciagPlanMapper.test.ts
+++ b/server/data/mappers/ciagPlanMapper.test.ts
@@ -1,0 +1,167 @@
+import {
+  aLongQuestionSetInductionDto,
+  aShortQuestionSetInductionDto,
+} from '../../testsupport/inductionDtoTestDataBuilder'
+import toCiagPlan from './ciagPlanMapper'
+import CiagPlan from '../ciagApi/interfaces/ciagPlan'
+import HopingToGetWorkValue from '../../enums/hopingToGetWorkValue'
+import ReasonToNotGetWorkValue from '../../enums/reasonToNotGetWorkValue'
+import AdditionalTrainingValue from '../../enums/additionalTrainingValue'
+import QualificationLevelValue from '../../enums/qualificationLevelValue'
+import InPrisonEducationValue from '../../enums/inPrisonEducationValue'
+import InPrisonWorkValue from '../../enums/inPrisonWorkValue'
+import AbilityToWorkValue from '../../enums/abilityToWorkValue'
+import EducationLevelValue from '../../enums/educationLevelValue'
+import PersonalInterestsValue from '../../enums/personalInterestsValue'
+import SkillsValue from '../../enums/skillsValue'
+import TypeOfWorkExperienceValue from '../../enums/typeOfWorkExperienceValue'
+import WorkInterestsValue from '../../enums/workInterestsValue'
+
+describe('ciagPlanMapper', () => {
+  it('should map to CiagPlan given a short question set Induction DTO', () => {
+    // Given
+    const prisonNumber = 'A1234BC'
+    const inductionDto = aShortQuestionSetInductionDto({ prisonNumber })
+
+    const expected: CiagPlan = {
+      offenderId: prisonNumber,
+      desireToWork: false,
+      hopingToGetWork: HopingToGetWorkValue.NO,
+      reasonToNotGetWork: [ReasonToNotGetWorkValue.HEALTH, ReasonToNotGetWorkValue.OTHER],
+      reasonToNotGetWorkOther: 'Will be of retirement age at release',
+      abilityToWork: null,
+      abilityToWorkOther: null,
+
+      // The properties workExperience, skillsAndInterests, qualificationsAndTraining and inPrisonInterests are
+      // fundamentally the difference between a short and long question set CiagPlan
+      workExperience: undefined,
+      skillsAndInterests: undefined,
+      qualificationsAndTraining: {
+        additionalTraining: [AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE, AdditionalTrainingValue.OTHER],
+        additionalTrainingOther: 'Beginners cookery for IT professionals',
+        educationLevel: null,
+        qualifications: [
+          { subject: 'English', level: QualificationLevelValue.LEVEL_6, grade: 'C' },
+          { subject: 'Maths', level: QualificationLevelValue.LEVEL_6, grade: 'A*' },
+        ],
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T10:39:44.000Z',
+      },
+      inPrisonInterests: {
+        inPrisonEducation: [
+          InPrisonEducationValue.FORKLIFT_DRIVING,
+          InPrisonEducationValue.CATERING,
+          InPrisonEducationValue.OTHER,
+        ],
+        inPrisonEducationOther: 'Advanced origami',
+        inPrisonWork: [InPrisonWorkValue.CLEANING_AND_HYGIENE, InPrisonWorkValue.OTHER],
+        inPrisonWorkOther: 'Gardening and grounds keeping',
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T10:39:44.000Z',
+      },
+
+      createdBy: 'asmith_gen',
+      createdDateTime: '2023-06-19T10:39:44.000Z',
+      modifiedBy: 'asmith_gen',
+      modifiedDateTime: '2023-06-19T10:39:44.000Z',
+      prisonId: 'MDI',
+      prisonName: undefined,
+    }
+
+    // When
+    const actual = toCiagPlan(inductionDto)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  it('should map to CiagPlan given a long question set Induction DTO', () => {
+    // Given
+    const prisonNumber = 'A1234BC'
+    const inductionDto = aLongQuestionSetInductionDto({ prisonNumber })
+
+    const expected: CiagPlan = {
+      offenderId: prisonNumber,
+      desireToWork: true,
+      hopingToGetWork: HopingToGetWorkValue.YES,
+      reasonToNotGetWork: null,
+      reasonToNotGetWorkOther: null,
+      abilityToWork: [AbilityToWorkValue.NONE],
+      abilityToWorkOther: null,
+
+      // The properties workExperience, skillsAndInterests, qualificationsAndTraining and inPrisonInterests are
+      // fundamentally the difference between a short and long question set CiagPlan
+      workExperience: {
+        hasWorkedBefore: true,
+        typeOfWorkExperience: [TypeOfWorkExperienceValue.CONSTRUCTION, TypeOfWorkExperienceValue.OTHER],
+        typeOfWorkExperienceOther: 'Retail delivery',
+        workExperience: [
+          {
+            typeOfWorkExperience: TypeOfWorkExperienceValue.CONSTRUCTION,
+            role: 'General labourer',
+            details: 'Groundwork and basic block work and bricklaying',
+          },
+          {
+            typeOfWorkExperience: TypeOfWorkExperienceValue.OTHER,
+            role: 'Milkman',
+            details: 'Self employed franchise operator delivering milk and associated diary products.',
+          },
+        ],
+        workInterests: {
+          workInterests: [WorkInterestsValue.RETAIL, WorkInterestsValue.CONSTRUCTION, WorkInterestsValue.OTHER],
+          workInterestsOther: 'Film, TV and media',
+          particularJobInterests: [
+            { workInterest: WorkInterestsValue.RETAIL, role: null },
+            { workInterest: WorkInterestsValue.CONSTRUCTION, role: 'General labourer' },
+            {
+              workInterest: WorkInterestsValue.OTHER,
+              role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+            },
+          ],
+          modifiedBy: 'asmith_gen',
+          modifiedDateTime: '2023-06-19T10:39:44.000Z',
+        },
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T10:39:44.000Z',
+      },
+      skillsAndInterests: {
+        personalInterests: [
+          PersonalInterestsValue.CREATIVE,
+          PersonalInterestsValue.DIGITAL,
+          PersonalInterestsValue.OTHER,
+        ],
+        personalInterestsOther: 'Renewable energy',
+        skills: [SkillsValue.TEAMWORK, SkillsValue.WILLINGNESS_TO_LEARN, SkillsValue.OTHER],
+        skillsOther: 'Tenacity',
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T10:39:44.000Z',
+      },
+      qualificationsAndTraining: {
+        additionalTraining: [
+          AdditionalTrainingValue.FIRST_AID_CERTIFICATE,
+          AdditionalTrainingValue.MANUAL_HANDLING,
+          AdditionalTrainingValue.OTHER,
+        ],
+        additionalTrainingOther: 'Advanced origami',
+        educationLevel: EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS,
+        qualifications: [{ subject: 'Pottery', level: QualificationLevelValue.LEVEL_4, grade: 'C' }],
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T10:39:44.000Z',
+      },
+      inPrisonInterests: undefined,
+
+      createdBy: 'asmith_gen',
+      createdDateTime: '2023-06-19T10:39:44.000Z',
+      modifiedBy: 'asmith_gen',
+      modifiedDateTime: '2023-06-19T10:39:44.000Z',
+      prisonId: 'MDI',
+      prisonName: undefined,
+    }
+
+    // When
+    const actual = toCiagPlan(inductionDto)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/data/mappers/ciagPlanMapper.test.ts
+++ b/server/data/mappers/ciagPlanMapper.test.ts
@@ -45,7 +45,7 @@ describe('ciagPlanMapper', () => {
           { subject: 'Maths', level: QualificationLevelValue.LEVEL_6, grade: 'A*' },
         ],
         modifiedBy: 'asmith_gen',
-        modifiedDateTime: '2023-06-19T10:39:44.000Z',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
       },
       inPrisonInterests: {
         inPrisonEducation: [
@@ -57,13 +57,13 @@ describe('ciagPlanMapper', () => {
         inPrisonWork: [InPrisonWorkValue.CLEANING_AND_HYGIENE, InPrisonWorkValue.OTHER],
         inPrisonWorkOther: 'Gardening and grounds keeping',
         modifiedBy: 'asmith_gen',
-        modifiedDateTime: '2023-06-19T10:39:44.000Z',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
       },
 
       createdBy: 'asmith_gen',
-      createdDateTime: '2023-06-19T10:39:44.000Z',
+      createdDateTime: '2023-06-19T09:39:44.000Z',
       modifiedBy: 'asmith_gen',
-      modifiedDateTime: '2023-06-19T10:39:44.000Z',
+      modifiedDateTime: '2023-06-19T09:39:44.000Z',
       prisonId: 'MDI',
       prisonName: undefined,
     }
@@ -119,10 +119,10 @@ describe('ciagPlanMapper', () => {
             },
           ],
           modifiedBy: 'asmith_gen',
-          modifiedDateTime: '2023-06-19T10:39:44.000Z',
+          modifiedDateTime: '2023-06-19T09:39:44.000Z',
         },
         modifiedBy: 'asmith_gen',
-        modifiedDateTime: '2023-06-19T10:39:44.000Z',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
       },
       skillsAndInterests: {
         personalInterests: [
@@ -134,7 +134,7 @@ describe('ciagPlanMapper', () => {
         skills: [SkillsValue.TEAMWORK, SkillsValue.WILLINGNESS_TO_LEARN, SkillsValue.OTHER],
         skillsOther: 'Tenacity',
         modifiedBy: 'asmith_gen',
-        modifiedDateTime: '2023-06-19T10:39:44.000Z',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
       },
       qualificationsAndTraining: {
         additionalTraining: [
@@ -146,14 +146,14 @@ describe('ciagPlanMapper', () => {
         educationLevel: EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS,
         qualifications: [{ subject: 'Pottery', level: QualificationLevelValue.LEVEL_4, grade: 'C' }],
         modifiedBy: 'asmith_gen',
-        modifiedDateTime: '2023-06-19T10:39:44.000Z',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
       },
       inPrisonInterests: undefined,
 
       createdBy: 'asmith_gen',
-      createdDateTime: '2023-06-19T10:39:44.000Z',
+      createdDateTime: '2023-06-19T09:39:44.000Z',
       modifiedBy: 'asmith_gen',
-      modifiedDateTime: '2023-06-19T10:39:44.000Z',
+      modifiedDateTime: '2023-06-19T09:39:44.000Z',
       prisonId: 'MDI',
       prisonName: undefined,
     }

--- a/server/data/mappers/ciagPlanMapper.ts
+++ b/server/data/mappers/ciagPlanMapper.ts
@@ -28,7 +28,7 @@ const toCiagPlan = (inductionDto: InductionDto): CiagPlan => {
     modifiedBy: inductionDto.updatedBy,
     modifiedDateTime: inductionDto.updatedAt.toISOString(),
     prisonId: inductionDto.updatedAtPrison,
-    prisonName: undefined, // TODO - check this is a sound decision (not sure what else we might be able to do here)
+    prisonName: undefined,
   }
 }
 

--- a/server/data/mappers/ciagPlanMapper.ts
+++ b/server/data/mappers/ciagPlanMapper.ts
@@ -1,0 +1,129 @@
+import type { InductionDto } from 'dto'
+import { format } from 'date-fns'
+import CiagPlan from '../ciagApi/interfaces/ciagPlan'
+import HopingToGetWorkValue from '../../enums/hopingToGetWorkValue'
+import TypeOfWorkExperienceValue from '../../enums/typeOfWorkExperienceValue'
+import WorkInterestsValue from '../../enums/workInterestsValue'
+import SkillsValue from '../../enums/skillsValue'
+import PersonalInterestsValue from '../../enums/personalInterestsValue'
+import InPrisonWorkValue from '../../enums/inPrisonWorkValue'
+import InPrisonEducationValue from '../../enums/inPrisonEducationValue'
+
+const toCiagPlan = (inductionDto: InductionDto): CiagPlan => {
+  return {
+    offenderId: inductionDto.prisonNumber,
+    desireToWork: inductionDto.workOnRelease.hopingToWork === HopingToGetWorkValue.YES,
+    hopingToGetWork: inductionDto.workOnRelease.hopingToWork,
+    reasonToNotGetWork: inductionDto.workOnRelease.notHopingToWorkReasons,
+    reasonToNotGetWorkOther: inductionDto.workOnRelease.notHopingToWorkOtherReason,
+    abilityToWork: inductionDto.workOnRelease.affectAbilityToWork,
+    abilityToWorkOther: inductionDto.workOnRelease.affectAbilityToWorkOther,
+
+    workExperience: toWorkExperience(inductionDto),
+    skillsAndInterests: toSkillsAndInterests(inductionDto),
+    qualificationsAndTraining: toQualificationsAndTraining(inductionDto),
+    inPrisonInterests: toInPrisonInterests(inductionDto),
+
+    createdBy: inductionDto.createdBy,
+    createdDateTime: format(inductionDto.createdAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+    modifiedBy: inductionDto.updatedBy,
+    modifiedDateTime: format(inductionDto.updatedAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+    prisonId: inductionDto.updatedAtPrison,
+    prisonName: undefined, // TODO - check this is a sound decision (not sure what else we might be able to do here)
+  }
+}
+
+const toWorkExperience = (inductionDto: InductionDto) => {
+  return inductionDto.previousWorkExperiences
+    ? {
+        hasWorkedBefore: inductionDto.previousWorkExperiences.hasWorkedBefore,
+        typeOfWorkExperience: inductionDto.previousWorkExperiences.experiences.map(
+          experience => experience.experienceType,
+        ),
+        typeOfWorkExperienceOther: inductionDto.previousWorkExperiences.experiences.find(
+          experience => experience.experienceType === TypeOfWorkExperienceValue.OTHER,
+        )?.experienceTypeOther,
+        workExperience: inductionDto.previousWorkExperiences.experiences.map(experience => {
+          return {
+            typeOfWorkExperience: experience.experienceType,
+            role: experience.role,
+            details: experience.details,
+          }
+        }),
+        modifiedBy: inductionDto.previousWorkExperiences.updatedBy,
+        modifiedDateTime: format(inductionDto.previousWorkExperiences.updatedAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+
+        workInterests: inductionDto.futureWorkInterests
+          ? {
+              workInterests: inductionDto.futureWorkInterests.interests.map(interest => interest.workType),
+              workInterestsOther: inductionDto.futureWorkInterests.interests.find(
+                interest => interest.workType === WorkInterestsValue.OTHER,
+              )?.workTypeOther,
+              particularJobInterests: inductionDto.futureWorkInterests.interests.map(interest => {
+                return {
+                  workInterest: interest.workType,
+                  role: interest.role,
+                }
+              }),
+              modifiedBy: inductionDto.futureWorkInterests.updatedBy,
+              modifiedDateTime: format(inductionDto.futureWorkInterests.updatedAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+            }
+          : undefined,
+      }
+    : undefined
+}
+
+const toSkillsAndInterests = (inductionDto: InductionDto) => {
+  return inductionDto.personalSkillsAndInterests
+    ? {
+        skills: inductionDto.personalSkillsAndInterests.skills.map(skill => skill.skillType),
+        skillsOther: inductionDto.personalSkillsAndInterests.skills.find(skill => skill.skillType === SkillsValue.OTHER)
+          ?.skillTypeOther,
+        personalInterests: inductionDto.personalSkillsAndInterests.interests.map(interest => interest.interestType),
+        personalInterestsOther: inductionDto.personalSkillsAndInterests.interests.find(
+          interest => interest.interestType === PersonalInterestsValue.OTHER,
+        )?.interestTypeOther,
+        modifiedBy: inductionDto.personalSkillsAndInterests.updatedBy,
+        modifiedDateTime: format(inductionDto.personalSkillsAndInterests.updatedAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+      }
+    : undefined
+}
+
+const toQualificationsAndTraining = (inductionDto: InductionDto) => {
+  return inductionDto.previousQualifications
+    ? {
+        educationLevel: inductionDto.previousQualifications.educationLevel,
+        qualifications: inductionDto.previousQualifications.qualifications.map(qualification => {
+          return {
+            subject: qualification.subject,
+            grade: qualification.grade,
+            level: qualification.level,
+          }
+        }),
+        additionalTraining: inductionDto.previousTraining?.trainingTypes || [],
+        additionalTrainingOther: inductionDto.previousTraining?.trainingTypeOther,
+        modifiedBy: inductionDto.previousQualifications.updatedBy,
+        modifiedDateTime: format(inductionDto.previousQualifications.updatedAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+      }
+    : undefined
+}
+const toInPrisonInterests = (inductionDto: InductionDto) => {
+  return inductionDto.inPrisonInterests
+    ? {
+        inPrisonWork: inductionDto.inPrisonInterests.inPrisonWorkInterests.map(workInterest => workInterest.workType),
+        inPrisonWorkOther: inductionDto.inPrisonInterests.inPrisonWorkInterests.find(
+          workInterest => workInterest.workType === InPrisonWorkValue.OTHER,
+        )?.workTypeOther,
+        inPrisonEducation: inductionDto.inPrisonInterests.inPrisonTrainingInterests.map(
+          educationInterest => educationInterest.trainingType,
+        ),
+        inPrisonEducationOther: inductionDto.inPrisonInterests.inPrisonTrainingInterests.find(
+          educationInterest => educationInterest.trainingType === InPrisonEducationValue.OTHER,
+        )?.trainingTypeOther,
+        modifiedBy: inductionDto.inPrisonInterests.updatedBy,
+        modifiedDateTime: format(inductionDto.inPrisonInterests.updatedAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+      }
+    : undefined
+}
+
+export default toCiagPlan

--- a/server/data/mappers/ciagPlanMapper.ts
+++ b/server/data/mappers/ciagPlanMapper.ts
@@ -1,5 +1,4 @@
 import type { InductionDto } from 'dto'
-import { format } from 'date-fns'
 import CiagPlan from '../ciagApi/interfaces/ciagPlan'
 import HopingToGetWorkValue from '../../enums/hopingToGetWorkValue'
 import TypeOfWorkExperienceValue from '../../enums/typeOfWorkExperienceValue'
@@ -25,9 +24,9 @@ const toCiagPlan = (inductionDto: InductionDto): CiagPlan => {
     inPrisonInterests: toInPrisonInterests(inductionDto),
 
     createdBy: inductionDto.createdBy,
-    createdDateTime: format(inductionDto.createdAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+    createdDateTime: inductionDto.createdAt.toISOString(),
     modifiedBy: inductionDto.updatedBy,
-    modifiedDateTime: format(inductionDto.updatedAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+    modifiedDateTime: inductionDto.updatedAt.toISOString(),
     prisonId: inductionDto.updatedAtPrison,
     prisonName: undefined, // TODO - check this is a sound decision (not sure what else we might be able to do here)
   }
@@ -51,7 +50,7 @@ const toWorkExperience = (inductionDto: InductionDto) => {
           }
         }),
         modifiedBy: inductionDto.previousWorkExperiences.updatedBy,
-        modifiedDateTime: format(inductionDto.previousWorkExperiences.updatedAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+        modifiedDateTime: inductionDto.previousWorkExperiences.updatedAt.toISOString(),
 
         workInterests: inductionDto.futureWorkInterests
           ? {
@@ -66,7 +65,7 @@ const toWorkExperience = (inductionDto: InductionDto) => {
                 }
               }),
               modifiedBy: inductionDto.futureWorkInterests.updatedBy,
-              modifiedDateTime: format(inductionDto.futureWorkInterests.updatedAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+              modifiedDateTime: inductionDto.futureWorkInterests.updatedAt.toISOString(),
             }
           : undefined,
       }
@@ -84,7 +83,7 @@ const toSkillsAndInterests = (inductionDto: InductionDto) => {
           interest => interest.interestType === PersonalInterestsValue.OTHER,
         )?.interestTypeOther,
         modifiedBy: inductionDto.personalSkillsAndInterests.updatedBy,
-        modifiedDateTime: format(inductionDto.personalSkillsAndInterests.updatedAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+        modifiedDateTime: inductionDto.personalSkillsAndInterests.updatedAt.toISOString(),
       }
     : undefined
 }
@@ -103,7 +102,7 @@ const toQualificationsAndTraining = (inductionDto: InductionDto) => {
         additionalTraining: inductionDto.previousTraining?.trainingTypes || [],
         additionalTrainingOther: inductionDto.previousTraining?.trainingTypeOther,
         modifiedBy: inductionDto.previousQualifications.updatedBy,
-        modifiedDateTime: format(inductionDto.previousQualifications.updatedAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+        modifiedDateTime: inductionDto.previousQualifications.updatedAt.toISOString(),
       }
     : undefined
 }
@@ -121,7 +120,7 @@ const toInPrisonInterests = (inductionDto: InductionDto) => {
           educationInterest => educationInterest.trainingType === InPrisonEducationValue.OTHER,
         )?.trainingTypeOther,
         modifiedBy: inductionDto.inPrisonInterests.updatedBy,
-        modifiedDateTime: format(inductionDto.inPrisonInterests.updatedAt, `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`),
+        modifiedDateTime: inductionDto.inPrisonInterests.updatedAt.toISOString(),
       }
     : undefined
 }


### PR DESCRIPTION
This PR adds a new mapper to map from an `InductionDTO` (the DTO representation of an Induction from the new Induction API) to a `CiagPlan` (the main API and view model class in the original CIAG UI and API)

The plan is to use this mapper to map from the `InductionDTO`  returned from the new Induction Service (added in a previous PR) into a `CiagPlan` which is then used in the controller and views; the overall objective being swapping out the existing `CiagService` and its call to the old CIAG API to replace it with a call to `InductionService` and the new Induction based API.