### PR TITLE
RR-570 - Added comparators so that arrays are correctly sorted in `ciagPlanMapper`

### DIFF
--- a/server/data/mappers/achievedQualificationDtoComparator.test.ts
+++ b/server/data/mappers/achievedQualificationDtoComparator.test.ts
@@ -1,0 +1,190 @@
+import type { AchievedQualificationDto } from 'dto'
+import QualificationLevelValue from '../../enums/qualificationLevelValue'
+import achievedQualificationDtoComparator from './achievedQualificationDtoComparator'
+
+describe('achievedQualificationDtoComparator', () => {
+  it('should determine if 2 qualification have equal qualification level, subject and grades', () => {
+    // Given
+    const qualification1: AchievedQualificationDto = {
+      level: QualificationLevelValue.LEVEL_4,
+      subject: 'Maths',
+      grade: 'A',
+    }
+    const qualification2: AchievedQualificationDto = {
+      level: QualificationLevelValue.LEVEL_4,
+      subject: 'Maths',
+      grade: 'A',
+    }
+
+    // When
+    const actual = achievedQualificationDtoComparator(qualification1, qualification2)
+
+    // Then
+    expect(actual).toEqual(0)
+  })
+
+  describe('primary comparison based on level', () => {
+    it(`should determine if a qualification's level is alphabetically before another qualification's level`, () => {
+      // Given
+      const qualification1: AchievedQualificationDto = {
+        level: QualificationLevelValue.LEVEL_8,
+        subject: 'English',
+        grade: 'C+',
+      }
+      const qualification2: AchievedQualificationDto = {
+        level: QualificationLevelValue.LEVEL_4,
+        subject: 'Maths',
+        grade: 'A',
+      }
+
+      // When
+      const actual = achievedQualificationDtoComparator(qualification1, qualification2)
+
+      // Then
+      expect(actual).toEqual(-1)
+    })
+
+    it(`should determine if a qualification's level is alphabetically after another qualification's level`, () => {
+      // Given
+      const qualification1: AchievedQualificationDto = {
+        level: QualificationLevelValue.LEVEL_4,
+        subject: 'Maths',
+        grade: 'A',
+      }
+      const qualification2: AchievedQualificationDto = {
+        level: QualificationLevelValue.LEVEL_8,
+        subject: 'English',
+        grade: 'C+',
+      }
+
+      // When
+      const actual = achievedQualificationDtoComparator(qualification1, qualification2)
+
+      // Then
+      expect(actual).toEqual(1)
+    })
+  })
+
+  describe('secondary comparison based on subject', () => {
+    it(`should determine if a qualification's subject is alphabetically before another qualification's subject`, () => {
+      // Given
+      const qualification1: AchievedQualificationDto = {
+        level: QualificationLevelValue.LEVEL_8,
+        subject: 'English',
+        grade: 'C+',
+      }
+      const qualification2: AchievedQualificationDto = {
+        level: QualificationLevelValue.LEVEL_8,
+        subject: 'Maths',
+        grade: 'A',
+      }
+
+      // When
+      const actual = achievedQualificationDtoComparator(qualification1, qualification2)
+
+      // Then
+      expect(actual).toEqual(-1)
+    })
+
+    it(`should determine if a qualification's subject is alphabetically after another qualification's subject`, () => {
+      // Given
+      const qualification1: AchievedQualificationDto = {
+        level: QualificationLevelValue.LEVEL_8,
+        subject: 'Maths',
+        grade: 'A',
+      }
+      const qualification2: AchievedQualificationDto = {
+        level: QualificationLevelValue.LEVEL_8,
+        subject: 'English',
+        grade: 'C+',
+      }
+
+      // When
+      const actual = achievedQualificationDtoComparator(qualification1, qualification2)
+
+      // Then
+      expect(actual).toEqual(1)
+    })
+  })
+
+  describe('tertiary comparison based on grade', () => {
+    it(`should determine if a qualification's grade is alphabetically before another qualification's grade`, () => {
+      // Given
+      const qualification1: AchievedQualificationDto = {
+        level: QualificationLevelValue.LEVEL_8,
+        subject: 'English',
+        grade: 'A',
+      }
+      const qualification2: AchievedQualificationDto = {
+        level: QualificationLevelValue.LEVEL_8,
+        subject: 'English',
+        grade: 'C+',
+      }
+
+      // When
+      const actual = achievedQualificationDtoComparator(qualification1, qualification2)
+
+      // Then
+      expect(actual).toEqual(-1)
+    })
+
+    it(`should determine if a qualification's grade is alphabetically after another qualification's grade`, () => {
+      // Given
+      const qualification1: AchievedQualificationDto = {
+        level: QualificationLevelValue.LEVEL_8,
+        subject: 'English',
+        grade: 'C+',
+      }
+      const qualification2: AchievedQualificationDto = {
+        level: QualificationLevelValue.LEVEL_8,
+        subject: 'English',
+        grade: 'A',
+      }
+
+      // When
+      const actual = achievedQualificationDtoComparator(qualification1, qualification2)
+
+      // Then
+      expect(actual).toEqual(1)
+    })
+  })
+
+  it('should sort an array of qualifications', () => {
+    // Given
+    const qualification1: AchievedQualificationDto = {
+      level: QualificationLevelValue.LEVEL_8,
+      subject: 'English',
+      grade: 'C+',
+    }
+    const qualification2: AchievedQualificationDto = {
+      level: QualificationLevelValue.LEVEL_4,
+      subject: 'Maths',
+      grade: 'A',
+    }
+    const qualification3: AchievedQualificationDto = {
+      level: QualificationLevelValue.ENTRY_LEVEL,
+      subject: 'Pottery',
+      grade: 'A',
+    }
+    const qualification4: AchievedQualificationDto = {
+      level: QualificationLevelValue.LEVEL_6,
+      subject: 'Metalwork',
+      grade: 'B',
+    }
+    const qualification5: AchievedQualificationDto = {
+      level: QualificationLevelValue.LEVEL_4,
+      subject: 'Maths',
+      grade: 'B',
+    }
+
+    const qualifications = [qualification1, qualification2, qualification3, qualification4, qualification5]
+
+    const expected = [qualification1, qualification4, qualification2, qualification5, qualification3] // sorted by level, subject and grade
+
+    // When
+    qualifications.sort(achievedQualificationDtoComparator)
+
+    // Then
+    expect(qualifications).toEqual(expected)
+  })
+})

--- a/server/data/mappers/achievedQualificationDtoComparator.ts
+++ b/server/data/mappers/achievedQualificationDtoComparator.ts
@@ -1,0 +1,51 @@
+import type { AchievedQualificationDto } from 'dto'
+
+/**
+ * Comparator function that compares two `AchievedQualificationDto` DTO instances, returning -1, 0 or 1 depending
+ * on whether the first `AchievedQualificationDto` is a higher level than the second `AchievedQualificationDto`, with a
+ * secondary comparison of the `AchievedQualificationDto` subject alphabetically, and a tertiary comparison of the
+ * `AchievedQualificationDto` grade alphabetically.
+ *
+ * Determining whether a `AchievedQualificationDto` is a "higher level" than another `AchievedQualificationDto` is achieved
+ * with a reverse alphabetic comparison on the `level` property. This works more by convenience than anything else because
+ * the current supported levels are 'ENTRY_LEVEL' | 'LEVEL_1' | 'LEVEL_2' | 'LEVEL_3' | 'LEVEL_4' | 'LEVEL_5' | 'LEVEL_6' | 'LEVEL_7' | 'LEVEL_8'
+ * If we were to add/rename levels where the alphabetic sorting did not represent their level then we would need to
+ * revisit this.
+ * Likewise, comparing and determining an order based on grade may need revisiting at some point - given that the grade
+ * field is free text which is "better"? - A*, A, 1st, First, 9, 1 etc
+ *
+ * This comparator function can be used to sort an array of `AchievedQualificationDto` DTO instances, resulting
+ * in the array being sorted alphabetically on the `level` property.
+ */
+const achievedQualificationDtoComparator = (
+  left: AchievedQualificationDto,
+  right: AchievedQualificationDto,
+): -1 | 0 | 1 => {
+  if (left.level > right.level) {
+    return -1
+  }
+  if (left.level < right.level) {
+    return 1
+  }
+
+  // The level property of each AchievedQualificationDto is equal. Apply a secondary comparison on the subject property.
+  if (left.subject > right.subject) {
+    return 1
+  }
+  if (left.subject < right.subject) {
+    return -1
+  }
+
+  // The level and grade properties of each AchievedQualificationDto is equal. Apply a tertiary comparison on the grade property.
+  if (left.grade > right.grade) {
+    return 1
+  }
+  if (left.grade < right.grade) {
+    return -1
+  }
+
+  // The two AchievedQualificationDto's have the same level, subject and grade.
+  return 0
+}
+
+export default achievedQualificationDtoComparator

--- a/server/data/mappers/ciagPlanMapper.test.ts
+++ b/server/data/mappers/ciagPlanMapper.test.ts
@@ -29,7 +29,7 @@ describe('ciagPlanMapper', () => {
       hopingToGetWork: HopingToGetWorkValue.NO,
       reasonToNotGetWork: [ReasonToNotGetWorkValue.HEALTH, ReasonToNotGetWorkValue.OTHER],
       reasonToNotGetWorkOther: 'Will be of retirement age at release',
-      abilityToWork: null,
+      abilityToWork: undefined,
       abilityToWorkOther: null,
 
       // The properties workExperience, skillsAndInterests, qualificationsAndTraining and inPrisonInterests are
@@ -49,8 +49,8 @@ describe('ciagPlanMapper', () => {
       },
       inPrisonInterests: {
         inPrisonEducation: [
-          InPrisonEducationValue.FORKLIFT_DRIVING,
           InPrisonEducationValue.CATERING,
+          InPrisonEducationValue.FORKLIFT_DRIVING,
           InPrisonEducationValue.OTHER,
         ],
         inPrisonEducationOther: 'Advanced origami',
@@ -84,7 +84,7 @@ describe('ciagPlanMapper', () => {
       offenderId: prisonNumber,
       desireToWork: true,
       hopingToGetWork: HopingToGetWorkValue.YES,
-      reasonToNotGetWork: null,
+      reasonToNotGetWork: undefined,
       reasonToNotGetWorkOther: null,
       abilityToWork: [AbilityToWorkValue.NONE],
       abilityToWorkOther: null,
@@ -108,11 +108,11 @@ describe('ciagPlanMapper', () => {
           },
         ],
         workInterests: {
-          workInterests: [WorkInterestsValue.RETAIL, WorkInterestsValue.CONSTRUCTION, WorkInterestsValue.OTHER],
+          workInterests: [WorkInterestsValue.CONSTRUCTION, WorkInterestsValue.RETAIL, WorkInterestsValue.OTHER],
           workInterestsOther: 'Film, TV and media',
           particularJobInterests: [
-            { workInterest: WorkInterestsValue.RETAIL, role: null },
             { workInterest: WorkInterestsValue.CONSTRUCTION, role: 'General labourer' },
+            { workInterest: WorkInterestsValue.RETAIL, role: null },
             {
               workInterest: WorkInterestsValue.OTHER,
               role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',

--- a/server/data/mappers/ciagPlanMapper.ts
+++ b/server/data/mappers/ciagPlanMapper.ts
@@ -7,15 +7,19 @@ import SkillsValue from '../../enums/skillsValue'
 import PersonalInterestsValue from '../../enums/personalInterestsValue'
 import InPrisonWorkValue from '../../enums/inPrisonWorkValue'
 import InPrisonEducationValue from '../../enums/inPrisonEducationValue'
+import enumComparator from './enumComparator'
+import previousWorkExperienceDtoComparator from './previousWorkExperienceDtoComparator'
+import futureWorkInterestDtoComparator from './futureWorkInterestDtoComparator'
+import achievedQualificationDtoComparator from './achievedQualificationDtoComparator'
 
 const toCiagPlan = (inductionDto: InductionDto): CiagPlan => {
   return {
     offenderId: inductionDto.prisonNumber,
     desireToWork: inductionDto.workOnRelease.hopingToWork === HopingToGetWorkValue.YES,
     hopingToGetWork: inductionDto.workOnRelease.hopingToWork,
-    reasonToNotGetWork: inductionDto.workOnRelease.notHopingToWorkReasons,
+    reasonToNotGetWork: inductionDto.workOnRelease.notHopingToWorkReasons?.sort(enumComparator),
     reasonToNotGetWorkOther: inductionDto.workOnRelease.notHopingToWorkOtherReason,
-    abilityToWork: inductionDto.workOnRelease.affectAbilityToWork,
+    abilityToWork: inductionDto.workOnRelease.affectAbilityToWork?.sort(enumComparator),
     abilityToWorkOther: inductionDto.workOnRelease.affectAbilityToWorkOther,
 
     workExperience: toWorkExperience(inductionDto),
@@ -36,34 +40,40 @@ const toWorkExperience = (inductionDto: InductionDto) => {
   return inductionDto.previousWorkExperiences
     ? {
         hasWorkedBefore: inductionDto.previousWorkExperiences.hasWorkedBefore,
-        typeOfWorkExperience: inductionDto.previousWorkExperiences.experiences.map(
-          experience => experience.experienceType,
-        ),
+        typeOfWorkExperience: inductionDto.previousWorkExperiences.experiences
+          .map(experience => experience.experienceType)
+          .sort(enumComparator),
         typeOfWorkExperienceOther: inductionDto.previousWorkExperiences.experiences.find(
           experience => experience.experienceType === TypeOfWorkExperienceValue.OTHER,
         )?.experienceTypeOther,
-        workExperience: inductionDto.previousWorkExperiences.experiences.map(experience => {
-          return {
-            typeOfWorkExperience: experience.experienceType,
-            role: experience.role,
-            details: experience.details,
-          }
-        }),
+        workExperience: inductionDto.previousWorkExperiences.experiences
+          .sort(previousWorkExperienceDtoComparator)
+          .map(experience => {
+            return {
+              typeOfWorkExperience: experience.experienceType,
+              role: experience.role,
+              details: experience.details,
+            }
+          }),
         modifiedBy: inductionDto.previousWorkExperiences.updatedBy,
         modifiedDateTime: inductionDto.previousWorkExperiences.updatedAt.toISOString(),
 
         workInterests: inductionDto.futureWorkInterests
           ? {
-              workInterests: inductionDto.futureWorkInterests.interests.map(interest => interest.workType),
+              workInterests: inductionDto.futureWorkInterests.interests
+                .map(interest => interest.workType)
+                .sort(enumComparator),
               workInterestsOther: inductionDto.futureWorkInterests.interests.find(
                 interest => interest.workType === WorkInterestsValue.OTHER,
               )?.workTypeOther,
-              particularJobInterests: inductionDto.futureWorkInterests.interests.map(interest => {
-                return {
-                  workInterest: interest.workType,
-                  role: interest.role,
-                }
-              }),
+              particularJobInterests: inductionDto.futureWorkInterests.interests
+                .sort(futureWorkInterestDtoComparator)
+                .map(interest => {
+                  return {
+                    workInterest: interest.workType,
+                    role: interest.role,
+                  }
+                }),
               modifiedBy: inductionDto.futureWorkInterests.updatedBy,
               modifiedDateTime: inductionDto.futureWorkInterests.updatedAt.toISOString(),
             }
@@ -75,10 +85,12 @@ const toWorkExperience = (inductionDto: InductionDto) => {
 const toSkillsAndInterests = (inductionDto: InductionDto) => {
   return inductionDto.personalSkillsAndInterests
     ? {
-        skills: inductionDto.personalSkillsAndInterests.skills.map(skill => skill.skillType),
+        skills: inductionDto.personalSkillsAndInterests.skills.map(skill => skill.skillType).sort(enumComparator),
         skillsOther: inductionDto.personalSkillsAndInterests.skills.find(skill => skill.skillType === SkillsValue.OTHER)
           ?.skillTypeOther,
-        personalInterests: inductionDto.personalSkillsAndInterests.interests.map(interest => interest.interestType),
+        personalInterests: inductionDto.personalSkillsAndInterests.interests
+          .map(interest => interest.interestType)
+          .sort(enumComparator),
         personalInterestsOther: inductionDto.personalSkillsAndInterests.interests.find(
           interest => interest.interestType === PersonalInterestsValue.OTHER,
         )?.interestTypeOther,
@@ -92,14 +104,16 @@ const toQualificationsAndTraining = (inductionDto: InductionDto) => {
   return inductionDto.previousQualifications
     ? {
         educationLevel: inductionDto.previousQualifications.educationLevel,
-        qualifications: inductionDto.previousQualifications.qualifications.map(qualification => {
-          return {
-            subject: qualification.subject,
-            grade: qualification.grade,
-            level: qualification.level,
-          }
-        }),
-        additionalTraining: inductionDto.previousTraining?.trainingTypes || [],
+        qualifications: inductionDto.previousQualifications.qualifications
+          .sort(achievedQualificationDtoComparator)
+          .map(qualification => {
+            return {
+              subject: qualification.subject,
+              grade: qualification.grade,
+              level: qualification.level,
+            }
+          }),
+        additionalTraining: (inductionDto.previousTraining?.trainingTypes || []).sort(enumComparator),
         additionalTrainingOther: inductionDto.previousTraining?.trainingTypeOther,
         modifiedBy: inductionDto.previousQualifications.updatedBy,
         modifiedDateTime: inductionDto.previousQualifications.updatedAt.toISOString(),
@@ -109,13 +123,15 @@ const toQualificationsAndTraining = (inductionDto: InductionDto) => {
 const toInPrisonInterests = (inductionDto: InductionDto) => {
   return inductionDto.inPrisonInterests
     ? {
-        inPrisonWork: inductionDto.inPrisonInterests.inPrisonWorkInterests.map(workInterest => workInterest.workType),
+        inPrisonWork: inductionDto.inPrisonInterests.inPrisonWorkInterests
+          .map(workInterest => workInterest.workType)
+          .sort(enumComparator),
         inPrisonWorkOther: inductionDto.inPrisonInterests.inPrisonWorkInterests.find(
           workInterest => workInterest.workType === InPrisonWorkValue.OTHER,
         )?.workTypeOther,
-        inPrisonEducation: inductionDto.inPrisonInterests.inPrisonTrainingInterests.map(
-          educationInterest => educationInterest.trainingType,
-        ),
+        inPrisonEducation: inductionDto.inPrisonInterests.inPrisonTrainingInterests
+          .map(educationInterest => educationInterest.trainingType)
+          .sort(enumComparator),
         inPrisonEducationOther: inductionDto.inPrisonInterests.inPrisonTrainingInterests.find(
           educationInterest => educationInterest.trainingType === InPrisonEducationValue.OTHER,
         )?.trainingTypeOther,

--- a/server/data/mappers/enumComparator.test.ts
+++ b/server/data/mappers/enumComparator.test.ts
@@ -1,0 +1,105 @@
+import enumComparator from './enumComparator'
+
+describe('enumComparator', () => {
+  it(`should determine if a ENUM string is alphabetically before another ENUM string`, () => {
+    // Given
+    const enumString1 = 'CLEANING_AND_HYGIENE'
+    const enumString2 = 'WOODWORK_AND_JOINERY'
+
+    // When
+    const actual = enumComparator(enumString1, enumString2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it(`should determine if a ENUM string is alphabetically before another ENUM string using character later in the string`, () => {
+    // Given
+    const enumString1 = 'PRISON_LAUNDRY'
+    const enumString2 = 'PRISON_LIBRARY'
+
+    // When
+    const actual = enumComparator(enumString1, enumString2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it(`should determine if a ENUM string is alphabetically after another ENUM string`, () => {
+    // Given
+    const enumString1 = 'RETIRED'
+    const enumString2 = 'HEALTH'
+
+    // When
+    const actual = enumComparator(enumString1, enumString2)
+
+    // Then
+    expect(actual).toEqual(1)
+  })
+
+  it(`should return 1 given a ENUM string which is 'OTHER' and another ENUM string is alphabetically before 'OTHER'`, () => {
+    // Given
+    const enumString1 = 'OTHER'
+    const enumString2 = 'CLEANING_AND_HYGIENE'
+
+    // When
+    const actual = enumComparator(enumString1, enumString2)
+
+    // Then
+    expect(actual).toEqual(1)
+  })
+
+  it(`should return 1 given a ENUM string which 'OTHER' and another ENUM string is alphabetically after 'OTHER'`, () => {
+    // Given
+    const enumString1 = 'OTHER'
+    const enumString2 = 'WOODWORK_AND_JOINERY'
+
+    // When
+    const actual = enumComparator(enumString1, enumString2)
+
+    // Then
+    expect(actual).toEqual(1)
+  })
+
+  it(`should return -1 given an ENUM string is alphabetically before 'OTHER' and ENUM string iss 'OTHER'`, () => {
+    // Given
+    const enumString1 = 'CLEANING_AND_HYGIENE'
+    const enumString2 = 'OTHER'
+
+    // When
+    const actual = enumComparator(enumString1, enumString2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it(`should return -1 given an ENUM string is alphabetically after 'OTHER' and ENUM string is 'OTHER'`, () => {
+    // Given
+    const enumString1 = 'WOODWORK_AND_JOINERY'
+    const enumString2 = 'OTHER'
+
+    // When
+    const actual = enumComparator(enumString1, enumString2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it('should sort an array ENUM strings alphabetically, but with OTHER at the end', () => {
+    // Given
+    const enumString1 = 'WELDING_AND_METALWORK'
+    const enumString2 = 'OTHER'
+    const enumString3 = 'BARBERING_AND_HAIRDRESSING'
+    const enumString4 = 'ENGLISH_LANGUAGE_SKILLS'
+
+    const enums = [enumString1, enumString2, enumString3, enumString4]
+
+    const expected = [enumString3, enumString4, enumString1, enumString2] // alphabetically on ENUM string, with OTHER at the end
+
+    // When
+    enums.sort(enumComparator)
+
+    // Then
+    expect(enums).toEqual(expected)
+  })
+})

--- a/server/data/mappers/enumComparator.ts
+++ b/server/data/mappers/enumComparator.ts
@@ -1,0 +1,25 @@
+/**
+ * Comparator function that compares ENUM strings, returning -1, 0 or 1 depending on whether the
+ * first string is alphabetically before, equal or after the second sting.
+ * If the first string is 'OTHER' then 1 is returned.
+ *
+ * This comparator function can be used to sort an array of ENUM strings, resulting in the array being sorted
+ * alphabetically, except 'OTHER' which will always be at the end of the array.
+ */
+const enumComparator = (left: string, right: string): -1 | 0 | 1 => {
+  if (left === 'OTHER') {
+    return 1
+  }
+  if (right === 'OTHER') {
+    return -1
+  }
+  if (left < right) {
+    return -1
+  }
+  if (left > right) {
+    return 1
+  }
+  return 0
+}
+
+export default enumComparator

--- a/server/data/mappers/futureWorkInterestDtoComparator.test.ts
+++ b/server/data/mappers/futureWorkInterestDtoComparator.test.ts
@@ -1,0 +1,161 @@
+import type { FutureWorkInterestDto } from 'dto'
+import WorkInterestsValue from '../../enums/workInterestsValue'
+import futureWorkInterestDtoComparator from './futureWorkInterestDtoComparator'
+
+describe('futureWorkInterestDtoComparator', () => {
+  it('should determine if 2 future work interests have equal work types', () => {
+    // Given
+    const futureWorkInterest1: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.CONSTRUCTION,
+      role: 'Builder',
+    }
+    const futureWorkInterest2: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.CONSTRUCTION,
+      role: 'Builders mate',
+    }
+
+    // When
+    const actual = futureWorkInterestDtoComparator(futureWorkInterest1, futureWorkInterest2)
+
+    // Then
+    expect(actual).toEqual(0)
+  })
+
+  it(`should determine if a future work interest's work type is alphabetically before another instance's work type`, () => {
+    // Given
+    const futureWorkInterest1: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.CONSTRUCTION,
+      role: 'Builder',
+    }
+    const futureWorkInterest2: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.RETAIL,
+      role: 'Shop assistant',
+    }
+
+    // When
+    const actual = futureWorkInterestDtoComparator(futureWorkInterest1, futureWorkInterest2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it(`should determine if a future work interest's work type is alphabetically after another instance's work type`, () => {
+    // Given
+    const futureWorkInterest1: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.RETAIL,
+      role: 'Shop assistant',
+    }
+    const futureWorkInterest2: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.CONSTRUCTION,
+      role: 'Builder',
+    }
+
+    // When
+    const actual = futureWorkInterestDtoComparator(futureWorkInterest1, futureWorkInterest2)
+
+    // Then
+    expect(actual).toEqual(1)
+  })
+
+  it(`should return 1 given future work interest with work type 'OTHER' and another instance's work type is alphabetically before 'OTHER'`, () => {
+    // Given
+    const futureWorkInterest1: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.OTHER,
+      role: 'Dental technician',
+    }
+    const futureWorkInterest2: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.CONSTRUCTION,
+      role: 'Builder',
+    }
+
+    // When
+    const actual = futureWorkInterestDtoComparator(futureWorkInterest1, futureWorkInterest2)
+
+    // Then
+    expect(actual).toEqual(1)
+  })
+
+  it(`should return 1 given future work interest with work type 'OTHER' and another instance's work type is alphabetically after 'OTHER'`, () => {
+    // Given
+    const futureWorkInterest1: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.OTHER,
+      role: 'Dental technician',
+    }
+    const futureWorkInterest2: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.WAREHOUSING,
+      role: 'Forklift driver',
+    }
+
+    // When
+    const actual = futureWorkInterestDtoComparator(futureWorkInterest1, futureWorkInterest2)
+
+    // Then
+    expect(actual).toEqual(1)
+  })
+
+  it(`should return -1 given future work interest with work type alphabetically before 'OTHER' and another instance's work type is 'OTHER'`, () => {
+    // Given
+    const futureWorkInterest1: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.CONSTRUCTION,
+      role: 'Builder',
+    }
+    const futureWorkInterest2: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.OTHER,
+      role: 'Dental technician',
+    }
+
+    // When
+    const actual = futureWorkInterestDtoComparator(futureWorkInterest1, futureWorkInterest2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it(`should return -1 given future work interest with work type alphabetically after 'OTHER' and another instance's work type is 'OTHER'`, () => {
+    // Given
+    const futureWorkInterest1: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.WAREHOUSING,
+      role: 'Forklift driver',
+    }
+    const futureWorkInterest2: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.OTHER,
+      role: 'Dental technician',
+    }
+
+    // When
+    const actual = futureWorkInterestDtoComparator(futureWorkInterest1, futureWorkInterest2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it('should sort an array of future work interests alphabetically on work type, but with OTHER at the end', () => {
+    // Given
+    const futureWorkInterest1: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.RETAIL,
+      role: 'Shop assistant',
+    }
+    const futureWorkInterest2: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.CONSTRUCTION,
+      role: 'Builder',
+    }
+    const futureWorkInterest3: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.OTHER,
+      role: 'Dental technician',
+    }
+    const futureWorkInterest4: FutureWorkInterestDto = {
+      workType: WorkInterestsValue.WAREHOUSING,
+      role: 'Forklift driver',
+    }
+
+    const futureWorkInterests = [futureWorkInterest1, futureWorkInterest2, futureWorkInterest3, futureWorkInterest4]
+
+    const expected = [futureWorkInterest2, futureWorkInterest1, futureWorkInterest4, futureWorkInterest3] // alphabetically on type, with OTHER at the end
+
+    // When
+    futureWorkInterests.sort(futureWorkInterestDtoComparator)
+
+    // Then
+    expect(futureWorkInterests).toEqual(expected)
+  })
+})

--- a/server/data/mappers/futureWorkInterestDtoComparator.ts
+++ b/server/data/mappers/futureWorkInterestDtoComparator.ts
@@ -1,4 +1,5 @@
 import type { FutureWorkInterestDto } from 'dto'
+import enumComparator from './enumComparator'
 
 /**
  * Comparator function that compares two `FutureWorkInterestDto` DTO instances, returning -1, 0 or 1 depending on whether the
@@ -9,19 +10,7 @@ import type { FutureWorkInterestDto } from 'dto'
  * alphabetically on the `workType` property, except 'OTHER' which will always be at the end of the array.
  */
 const futureWorkInterestDtoComparator = (left: FutureWorkInterestDto, right: FutureWorkInterestDto): -1 | 0 | 1 => {
-  if (left.workType === 'OTHER') {
-    return 1
-  }
-  if (right.workType === 'OTHER') {
-    return -1
-  }
-  if (left.workType > right.workType) {
-    return 1
-  }
-  if (left.workType < right.workType) {
-    return -1
-  }
-  return 0
+  return enumComparator(left.workType, right.workType)
 }
 
 export default futureWorkInterestDtoComparator

--- a/server/data/mappers/futureWorkInterestDtoComparator.ts
+++ b/server/data/mappers/futureWorkInterestDtoComparator.ts
@@ -1,0 +1,27 @@
+import type { FutureWorkInterestDto } from 'dto'
+
+/**
+ * Comparator function that compares two `FutureWorkInterestDto` DTO instances, returning -1, 0 or 1 depending on whether the
+ * first interest's  workType property is alphabetically before, equal or after the second interest's workType property.
+ * If the first interest's workType is 'OTHER' then 1 is returned.
+ *
+ * This comparator function can be used to sort an array of `FutureWorkInterestDto` DTO instances, resulting in the array being sorted
+ * alphabetically on the `workType` property, except 'OTHER' which will always be at the end of the array.
+ */
+const futureWorkInterestDtoComparator = (left: FutureWorkInterestDto, right: FutureWorkInterestDto): -1 | 0 | 1 => {
+  if (left.workType === 'OTHER') {
+    return 1
+  }
+  if (right.workType === 'OTHER') {
+    return -1
+  }
+  if (left.workType > right.workType) {
+    return 1
+  }
+  if (left.workType < right.workType) {
+    return -1
+  }
+  return 0
+}
+
+export default futureWorkInterestDtoComparator

--- a/server/data/mappers/previousWorkExperienceDtoComparator.test.ts
+++ b/server/data/mappers/previousWorkExperienceDtoComparator.test.ts
@@ -1,0 +1,171 @@
+import type { PreviousWorkExperienceDto } from 'dto'
+import TypeOfWorkExperienceValue from '../../enums/typeOfWorkExperienceValue'
+import previousWorkExperienceDtoComparator from './previousWorkExperienceDtoComparator'
+
+describe('previousWorkExperienceDtoComparator', () => {
+  it('should determine if 2 previous work experiences have equal experience types', () => {
+    // Given
+    const previousWorkExperience1: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.CONSTRUCTION,
+      role: 'Builder',
+    }
+    const previousWorkExperience2: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.CONSTRUCTION,
+      role: 'Builders mate',
+    }
+
+    // When
+    const actual = previousWorkExperienceDtoComparator(previousWorkExperience1, previousWorkExperience2)
+
+    // Then
+    expect(actual).toEqual(0)
+  })
+
+  it(`should determine if a previous work experience's experience type is alphabetically before another instance's experience type`, () => {
+    // Given
+    const previousWorkExperience1: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.CONSTRUCTION,
+      role: 'Builder',
+    }
+    const previousWorkExperience2: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.RETAIL,
+      role: 'Shop assistant',
+    }
+
+    // When
+    const actual = previousWorkExperienceDtoComparator(previousWorkExperience1, previousWorkExperience2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it(`should determine if a previous work experience's experience type is alphabetically after another instance's experience type`, () => {
+    // Given
+    const previousWorkExperience1: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.RETAIL,
+      role: 'Shop assistant',
+    }
+    const previousWorkExperience2: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.CONSTRUCTION,
+      role: 'Builder',
+    }
+
+    // When
+    const actual = previousWorkExperienceDtoComparator(previousWorkExperience1, previousWorkExperience2)
+
+    // Then
+    expect(actual).toEqual(1)
+  })
+
+  it(`should return 1 given previous work experience with experience type 'OTHER' and another instance's experience type is alphabetically before 'OTHER'`, () => {
+    // Given
+    const previousWorkExperience1: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.OTHER,
+      role: 'Dental technician',
+    }
+    const previousWorkExperience2: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.CONSTRUCTION,
+      role: 'Builder',
+    }
+
+    // When
+    const actual = previousWorkExperienceDtoComparator(previousWorkExperience1, previousWorkExperience2)
+
+    // Then
+    expect(actual).toEqual(1)
+  })
+
+  it(`should return 1 given previous work experience with experience type 'OTHER' and another instance's experience type is alphabetically after 'OTHER'`, () => {
+    // Given
+    const previousWorkExperience1: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.OTHER,
+      role: 'Dental technician',
+    }
+    const previousWorkExperience2: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.WAREHOUSING,
+      role: 'Forklift driver',
+    }
+
+    // When
+    const actual = previousWorkExperienceDtoComparator(previousWorkExperience1, previousWorkExperience2)
+
+    // Then
+    expect(actual).toEqual(1)
+  })
+
+  it(`should return -1 given previous work experience with experience type alphabetically before 'OTHER' and another instance's experience type is 'OTHER'`, () => {
+    // Given
+    const previousWorkExperience1: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.CONSTRUCTION,
+      role: 'Builder',
+    }
+    const previousWorkExperience2: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.OTHER,
+      role: 'Dental technician',
+    }
+
+    // When
+    const actual = previousWorkExperienceDtoComparator(previousWorkExperience1, previousWorkExperience2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it(`should return -1 given previous work experience with experience type alphabetically after 'OTHER' and another instance's experience type is 'OTHER'`, () => {
+    // Given
+    const previousWorkExperience1: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.WAREHOUSING,
+      role: 'Forklift driver',
+    }
+    const previousWorkExperience2: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.OTHER,
+      role: 'Dental technician',
+    }
+
+    // When
+    const actual = previousWorkExperienceDtoComparator(previousWorkExperience1, previousWorkExperience2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it('should sort an array of previous work experiences alphabetically on experience type, but with OTHER at the end', () => {
+    // Given
+    const previousWorkExperience1: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.RETAIL,
+      role: 'Shop assistant',
+    }
+    const previousWorkExperience2: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.CONSTRUCTION,
+      role: 'Builder',
+    }
+    const previousWorkExperience3: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.OTHER,
+      role: 'Dental technician',
+    }
+    const previousWorkExperience4: PreviousWorkExperienceDto = {
+      experienceType: TypeOfWorkExperienceValue.WAREHOUSING,
+      role: 'Forklift driver',
+    }
+
+    const previousWorkExperiences = [
+      previousWorkExperience1,
+      previousWorkExperience2,
+      previousWorkExperience3,
+      previousWorkExperience4,
+    ]
+
+    const expected = [
+      previousWorkExperience2,
+      previousWorkExperience1,
+      previousWorkExperience4,
+      previousWorkExperience3,
+    ] // alphabetically on type, with OTHER at the end
+
+    // When
+    previousWorkExperiences.sort(previousWorkExperienceDtoComparator)
+
+    // Then
+    expect(previousWorkExperiences).toEqual(expected)
+  })
+})

--- a/server/data/mappers/previousWorkExperienceDtoComparator.ts
+++ b/server/data/mappers/previousWorkExperienceDtoComparator.ts
@@ -1,4 +1,5 @@
 import type { PreviousWorkExperienceDto } from 'dto'
+import enumComparator from './enumComparator'
 
 /**
  * Comparator function that compares two `PreviousWorkExperienceDto` DTO instances, returning -1, 0 or 1 depending on whether the
@@ -12,19 +13,7 @@ const previousWorkExperienceDtoComparator = (
   left: PreviousWorkExperienceDto,
   right: PreviousWorkExperienceDto,
 ): -1 | 0 | 1 => {
-  if (left.experienceType === 'OTHER') {
-    return 1
-  }
-  if (right.experienceType === 'OTHER') {
-    return -1
-  }
-  if (left.experienceType > right.experienceType) {
-    return 1
-  }
-  if (left.experienceType < right.experienceType) {
-    return -1
-  }
-  return 0
+  return enumComparator(left.experienceType, right.experienceType)
 }
 
 export default previousWorkExperienceDtoComparator

--- a/server/data/mappers/previousWorkExperienceDtoComparator.ts
+++ b/server/data/mappers/previousWorkExperienceDtoComparator.ts
@@ -1,0 +1,30 @@
+import type { PreviousWorkExperienceDto } from 'dto'
+
+/**
+ * Comparator function that compares two `PreviousWorkExperienceDto` DTO instances, returning -1, 0 or 1 depending on whether the
+ * first experience's experienceType property is alphabetically before, equal or after the second experience's experienceType property.
+ * If the first job's type is 'OTHER' then 1 is returned.
+ *
+ * This comparator function can be used to sort an array of `PreviousWorkExperienceDto` DTO instances, resulting in the array being sorted
+ * alphabetically on the `experienceType` property, except 'OTHER' which will always be at the end of the array.
+ */
+const previousWorkExperienceDtoComparator = (
+  left: PreviousWorkExperienceDto,
+  right: PreviousWorkExperienceDto,
+): -1 | 0 | 1 => {
+  if (left.experienceType === 'OTHER') {
+    return 1
+  }
+  if (right.experienceType === 'OTHER') {
+    return -1
+  }
+  if (left.experienceType > right.experienceType) {
+    return 1
+  }
+  if (left.experienceType < right.experienceType) {
+    return -1
+  }
+  return 0
+}
+
+export default previousWorkExperienceDtoComparator


### PR DESCRIPTION
This PR adds comparators so that arrays are correctly sorted in `ciagPlanMapper`.
Specifically this is to address the UI requirement that arrays/lists of things (such as job interests, work experience types etc etc) are sorted consistently and alphabetically, but with "OTHER" always at the end.

In the PLP UI we already do this with comparators (much like the ones I've ~copied~ introduced here)

The existing code in the CIAG UI (that we are looking to replace) also already does this, but with something that we are probably looking to delete