### PR TITLE
RR-597 - CreateOrUpdateInductionDtoMapper

### DIFF
--- a/server/data/mappers/createOrUpdateInductionDtoMapper.test.ts
+++ b/server/data/mappers/createOrUpdateInductionDtoMapper.test.ts
@@ -1,0 +1,162 @@
+import CiagPlan from '../ciagApi/interfaces/ciagPlan'
+import HopingToGetWorkValue from '../../enums/hopingToGetWorkValue'
+import ReasonToNotGetWorkValue from '../../enums/reasonToNotGetWorkValue'
+import AdditionalTrainingValue from '../../enums/additionalTrainingValue'
+import QualificationLevelValue from '../../enums/qualificationLevelValue'
+import InPrisonEducationValue from '../../enums/inPrisonEducationValue'
+import InPrisonWorkValue from '../../enums/inPrisonWorkValue'
+import AbilityToWorkValue from '../../enums/abilityToWorkValue'
+import EducationLevelValue from '../../enums/educationLevelValue'
+import PersonalInterestsValue from '../../enums/personalInterestsValue'
+import SkillsValue from '../../enums/skillsValue'
+import TypeOfWorkExperienceValue from '../../enums/typeOfWorkExperienceValue'
+import WorkInterestsValue from '../../enums/workInterestsValue'
+import {
+  aCreateLongQuestionSetInductionDto,
+  aCreateShortQuestionSetInductionDto,
+} from '../../testsupport/createInductionDtoTestDataBuilder'
+import toCreateOrUpdateInductionDto from './createOrUpdateInductionDtoMapper'
+
+describe('createOrUpdateInductionDtoMapper', () => {
+  it('should map to CreateOrUpdateInductionDto given a short question set CiagPlan', () => {
+    // Given
+    const prisonNumber = 'A1234BC'
+    const ciagPlan: CiagPlan = {
+      offenderId: prisonNumber,
+      desireToWork: false,
+      hopingToGetWork: HopingToGetWorkValue.NO,
+      reasonToNotGetWork: [ReasonToNotGetWorkValue.HEALTH, ReasonToNotGetWorkValue.OTHER],
+      reasonToNotGetWorkOther: 'Will be of retirement age at release',
+      abilityToWork: undefined,
+      abilityToWorkOther: undefined,
+      // The properties workExperience, skillsAndInterests, qualificationsAndTraining and inPrisonInterests are
+      // fundamentally the difference between a short and long question set CiagPlan
+      workExperience: undefined,
+      skillsAndInterests: undefined,
+      qualificationsAndTraining: {
+        additionalTraining: [AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE, AdditionalTrainingValue.OTHER],
+        additionalTrainingOther: 'Beginners cookery for IT professionals',
+        educationLevel: undefined,
+        qualifications: [
+          { subject: 'English', level: QualificationLevelValue.LEVEL_6, grade: 'C' },
+          { subject: 'Maths', level: QualificationLevelValue.LEVEL_6, grade: 'A*' },
+        ],
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      },
+      inPrisonInterests: {
+        inPrisonEducation: [
+          InPrisonEducationValue.FORKLIFT_DRIVING,
+          InPrisonEducationValue.CATERING,
+          InPrisonEducationValue.OTHER,
+        ],
+        inPrisonEducationOther: 'Advanced origami',
+        inPrisonWork: [InPrisonWorkValue.CLEANING_AND_HYGIENE, InPrisonWorkValue.OTHER],
+        inPrisonWorkOther: 'Gardening and grounds keeping',
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      },
+      createdBy: 'asmith_gen',
+      createdDateTime: '2023-06-19T09:39:44.000Z',
+      modifiedBy: 'asmith_gen',
+      modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      prisonId: 'BXI',
+      prisonName: undefined,
+    }
+    const expected = aCreateShortQuestionSetInductionDto()
+
+    // When
+    const actual = toCreateOrUpdateInductionDto(ciagPlan)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  it('should map to CreateOrUpdateInductionDto given a long question set CiagPlan', () => {
+    // Given
+    const prisonNumber = 'A1234BC'
+    const ciagPlan: CiagPlan = {
+      offenderId: prisonNumber,
+      desireToWork: true,
+      hopingToGetWork: HopingToGetWorkValue.YES,
+      reasonToNotGetWork: undefined,
+      reasonToNotGetWorkOther: undefined,
+      abilityToWork: [AbilityToWorkValue.NONE],
+      abilityToWorkOther: undefined,
+
+      // The properties workExperience, skillsAndInterests, qualificationsAndTraining and inPrisonInterests are
+      // fundamentally the difference between a short and long question set CiagPlan
+      workExperience: {
+        hasWorkedBefore: true,
+        typeOfWorkExperience: [TypeOfWorkExperienceValue.CONSTRUCTION, TypeOfWorkExperienceValue.OTHER],
+        typeOfWorkExperienceOther: 'Retail delivery',
+        workExperience: [
+          {
+            typeOfWorkExperience: TypeOfWorkExperienceValue.CONSTRUCTION,
+            role: 'General labourer',
+            details: 'Groundwork and basic block work and bricklaying',
+          },
+          {
+            typeOfWorkExperience: TypeOfWorkExperienceValue.OTHER,
+            role: 'Milkman',
+            details: 'Self employed franchise operator delivering milk and associated diary products.',
+          },
+        ],
+        workInterests: {
+          workInterests: [WorkInterestsValue.RETAIL, WorkInterestsValue.CONSTRUCTION, WorkInterestsValue.OTHER],
+          workInterestsOther: 'Film, TV and media',
+          particularJobInterests: [
+            { workInterest: WorkInterestsValue.RETAIL, role: undefined },
+            { workInterest: WorkInterestsValue.CONSTRUCTION, role: 'General labourer' },
+            {
+              workInterest: WorkInterestsValue.OTHER,
+              role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+            },
+          ],
+          modifiedBy: 'asmith_gen',
+          modifiedDateTime: '2023-06-19T09:39:44.000Z',
+        },
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      },
+      skillsAndInterests: {
+        personalInterests: [
+          PersonalInterestsValue.CREATIVE,
+          PersonalInterestsValue.DIGITAL,
+          PersonalInterestsValue.OTHER,
+        ],
+        personalInterestsOther: 'Renewable energy',
+        skills: [SkillsValue.TEAMWORK, SkillsValue.WILLINGNESS_TO_LEARN, SkillsValue.OTHER],
+        skillsOther: 'Tenacity',
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      },
+      qualificationsAndTraining: {
+        additionalTraining: [
+          AdditionalTrainingValue.FIRST_AID_CERTIFICATE,
+          AdditionalTrainingValue.MANUAL_HANDLING,
+          AdditionalTrainingValue.OTHER,
+        ],
+        additionalTrainingOther: 'Advanced origami',
+        educationLevel: EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS,
+        qualifications: [{ subject: 'Pottery', level: QualificationLevelValue.LEVEL_4, grade: 'C' }],
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      },
+      inPrisonInterests: undefined,
+      createdBy: 'asmith_gen',
+      createdDateTime: '2023-06-19T09:39:44.000Z',
+      modifiedBy: 'asmith_gen',
+      modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      prisonId: 'BXI',
+      prisonName: undefined,
+    }
+    const expected = aCreateLongQuestionSetInductionDto()
+
+    // When
+    const actual = toCreateOrUpdateInductionDto(ciagPlan)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/data/mappers/createOrUpdateInductionDtoMapper.ts
+++ b/server/data/mappers/createOrUpdateInductionDtoMapper.ts
@@ -1,0 +1,121 @@
+import type { CreateOrUpdateInductionDto } from 'dto'
+import CiagPlan from '../ciagApi/interfaces/ciagPlan'
+
+const toCreateOrUpdateInductionDto = (ciagPlan: CiagPlan): CreateOrUpdateInductionDto => {
+  return {
+    reference: undefined,
+    prisonId: ciagPlan.prisonId,
+    workOnRelease: toCreateOrUpdateWorkOnReleaseDto(ciagPlan),
+    previousQualifications: toCreateOrUpdatePreviousQualificationsDto(ciagPlan),
+    previousTraining: toCreateOrUpdatePreviousTrainingDto(ciagPlan),
+    previousWorkExperiences: toCreateOrUpdatePreviousWorkExperiencesDto(ciagPlan),
+    inPrisonInterests: toCreateOrUpdateInPrisonInterestsDto(ciagPlan),
+    personalSkillsAndInterests: toCreateOrUpdatePersonalSkillsAndInterestsDto(ciagPlan),
+    futureWorkInterests: toCreateOrUpdateFutureWorkInterestsDto(ciagPlan),
+  }
+}
+
+const toCreateOrUpdateWorkOnReleaseDto = (ciagPlan: CiagPlan) => {
+  return {
+    hopingToWork: ciagPlan.hopingToGetWork,
+    notHopingToWorkReasons: ciagPlan.reasonToNotGetWork,
+    notHopingToWorkOtherReason: ciagPlan.reasonToNotGetWorkOther,
+    affectAbilityToWork: ciagPlan.abilityToWork,
+    affectAbilityToWorkOther: ciagPlan.abilityToWorkOther,
+  }
+}
+const toCreateOrUpdatePreviousQualificationsDto = (ciagPlan: CiagPlan) => {
+  return ciagPlan.qualificationsAndTraining
+    ? {
+        educationLevel: ciagPlan.qualificationsAndTraining.educationLevel,
+        qualifications: ciagPlan.qualificationsAndTraining.qualifications.map(qualification => {
+          return {
+            subject: qualification.subject,
+            grade: qualification.grade,
+            level: qualification.level,
+          }
+        }),
+      }
+    : undefined
+}
+const toCreateOrUpdatePreviousTrainingDto = (ciagPlan: CiagPlan) => {
+  return ciagPlan.qualificationsAndTraining
+    ? {
+        trainingTypes: ciagPlan.qualificationsAndTraining.additionalTraining,
+        trainingTypeOther: ciagPlan.qualificationsAndTraining.additionalTrainingOther,
+      }
+    : undefined
+}
+
+const toCreateOrUpdatePreviousWorkExperiencesDto = (ciagPlan: CiagPlan) => {
+  return ciagPlan.workExperience
+    ? {
+        hasWorkedBefore: ciagPlan.workExperience.hasWorkedBefore,
+        experiences: ciagPlan.workExperience.workExperience.map(experience => {
+          return {
+            experienceType: experience.typeOfWorkExperience,
+            experienceTypeOther:
+              experience.typeOfWorkExperience === 'OTHER'
+                ? ciagPlan.workExperience.typeOfWorkExperienceOther
+                : undefined,
+            role: experience.role,
+            details: experience.details,
+          }
+        }),
+      }
+    : undefined
+}
+const toCreateOrUpdateInPrisonInterestsDto = (ciagPlan: CiagPlan) => {
+  return ciagPlan.inPrisonInterests
+    ? {
+        inPrisonWorkInterests: ciagPlan.inPrisonInterests.inPrisonWork.map(workInterest => {
+          return {
+            workType: workInterest,
+            workTypeOther: workInterest === 'OTHER' ? ciagPlan.inPrisonInterests.inPrisonWorkOther : undefined,
+          }
+        }),
+        inPrisonTrainingInterests: ciagPlan.inPrisonInterests.inPrisonEducation.map(trainingInterest => {
+          return {
+            trainingType: trainingInterest,
+            trainingTypeOther:
+              trainingInterest === 'OTHER' ? ciagPlan.inPrisonInterests.inPrisonEducationOther : undefined,
+          }
+        }),
+      }
+    : undefined
+}
+const toCreateOrUpdatePersonalSkillsAndInterestsDto = (ciagPlan: CiagPlan) => {
+  return ciagPlan.skillsAndInterests
+    ? {
+        skills: ciagPlan.skillsAndInterests.skills.map(skill => {
+          return {
+            skillType: skill,
+            skillTypeOther: skill === 'OTHER' ? ciagPlan.skillsAndInterests.skillsOther : undefined,
+          }
+        }),
+        interests: ciagPlan.skillsAndInterests.personalInterests.map(interest => {
+          return {
+            interestType: interest,
+            interestTypeOther: interest === 'OTHER' ? ciagPlan.skillsAndInterests.personalInterestsOther : undefined,
+          }
+        }),
+      }
+    : undefined
+}
+const toCreateOrUpdateFutureWorkInterestsDto = (ciagPlan: CiagPlan) => {
+  return ciagPlan.workExperience?.workInterests
+    ? {
+        interests: ciagPlan.workExperience.workInterests.workInterests.map(interest => {
+          return {
+            workType: interest,
+            workTypeOther: interest === 'OTHER' ? ciagPlan.workExperience.workInterests.workInterestsOther : undefined,
+            role: ciagPlan.workExperience.workInterests.particularJobInterests?.find(
+              element => element.workInterest === interest,
+            )?.role,
+          }
+        }),
+      }
+    : undefined
+}
+
+export default toCreateOrUpdateInductionDto

--- a/server/testsupport/createInductionDtoTestDataBuilder.ts
+++ b/server/testsupport/createInductionDtoTestDataBuilder.ts
@@ -22,9 +22,9 @@ const aCreateLongQuestionSetInductionDto = (options?: {
     workOnRelease: {
       hopingToWork: HopingToGetWorkValue.YES,
       affectAbilityToWork: [AbilityToWorkValue.NONE],
-      affectAbilityToWorkOther: null,
-      notHopingToWorkReasons: null,
-      notHopingToWorkOtherReason: null,
+      affectAbilityToWorkOther: undefined,
+      notHopingToWorkReasons: undefined,
+      notHopingToWorkOtherReason: undefined,
     },
     previousWorkExperiences: {
       hasWorkedBefore:
@@ -39,7 +39,7 @@ const aCreateLongQuestionSetInductionDto = (options?: {
           ? [
               {
                 experienceType: TypeOfWorkExperienceValue.CONSTRUCTION,
-                experienceTypeOther: null,
+                experienceTypeOther: undefined,
                 role: 'General labourer',
                 details: 'Groundwork and basic block work and bricklaying',
               },
@@ -56,12 +56,12 @@ const aCreateLongQuestionSetInductionDto = (options?: {
       interests: [
         {
           workType: WorkInterestsValue.RETAIL,
-          workTypeOther: null,
-          role: null,
+          workTypeOther: undefined,
+          role: undefined,
         },
         {
           workType: WorkInterestsValue.CONSTRUCTION,
-          workTypeOther: null,
+          workTypeOther: undefined,
           role: 'General labourer',
         },
         {
@@ -75,16 +75,16 @@ const aCreateLongQuestionSetInductionDto = (options?: {
       skills:
         !options || options.hasSkills === null || options.hasSkills === undefined || options.hasSkills === true
           ? [
-              { skillType: SkillsValue.TEAMWORK, skillTypeOther: null },
-              { skillType: SkillsValue.WILLINGNESS_TO_LEARN, skillTypeOther: null },
+              { skillType: SkillsValue.TEAMWORK, skillTypeOther: undefined },
+              { skillType: SkillsValue.WILLINGNESS_TO_LEARN, skillTypeOther: undefined },
               { skillType: SkillsValue.OTHER, skillTypeOther: 'Tenacity' },
             ]
           : [],
       interests:
         !options || options.hasInterests === null || options.hasInterests === undefined || options.hasInterests === true
           ? [
-              { interestType: PersonalInterestsValue.CREATIVE, interestTypeOther: null },
-              { interestType: PersonalInterestsValue.DIGITAL, interestTypeOther: null },
+              { interestType: PersonalInterestsValue.CREATIVE, interestTypeOther: undefined },
+              { interestType: PersonalInterestsValue.DIGITAL, interestTypeOther: undefined },
               { interestType: PersonalInterestsValue.OTHER, interestTypeOther: 'Renewable energy' },
             ]
           : [],
@@ -117,24 +117,24 @@ const aCreateShortQuestionSetInductionDto = (options?: {
     ...baseDtoTemplate(),
     workOnRelease: {
       hopingToWork: options?.hopingToGetWork || HopingToGetWorkValue.NO,
-      affectAbilityToWork: null,
-      affectAbilityToWorkOther: null,
+      affectAbilityToWork: undefined,
+      affectAbilityToWorkOther: undefined,
       notHopingToWorkReasons: [ReasonToNotGetWorkValue.HEALTH, ReasonToNotGetWorkValue.OTHER],
       notHopingToWorkOtherReason: 'Will be of retirement age at release',
     },
     inPrisonInterests: {
       inPrisonWorkInterests: [
-        { workType: InPrisonWorkValue.CLEANING_AND_HYGIENE, workTypeOther: null },
+        { workType: InPrisonWorkValue.CLEANING_AND_HYGIENE, workTypeOther: undefined },
         { workType: InPrisonWorkValue.OTHER, workTypeOther: 'Gardening and grounds keeping' },
       ],
       inPrisonTrainingInterests: [
-        { trainingType: InPrisonEducationValue.FORKLIFT_DRIVING, trainingTypeOther: null },
-        { trainingType: InPrisonEducationValue.CATERING, trainingTypeOther: null },
+        { trainingType: InPrisonEducationValue.FORKLIFT_DRIVING, trainingTypeOther: undefined },
+        { trainingType: InPrisonEducationValue.CATERING, trainingTypeOther: undefined },
         { trainingType: InPrisonEducationValue.OTHER, trainingTypeOther: 'Advanced origami' },
       ],
     },
     previousQualifications: {
-      educationLevel: null,
+      educationLevel: undefined,
       qualifications: [
         {
           subject: 'English',

--- a/server/testsupport/createInductionRequestTestDataBuilder.ts
+++ b/server/testsupport/createInductionRequestTestDataBuilder.ts
@@ -22,9 +22,9 @@ const aCreateLongQuestionSetInduction = (options?: {
     workOnRelease: {
       hopingToWork: HopingToGetWorkValue.YES,
       affectAbilityToWork: [AbilityToWorkValue.NONE],
-      affectAbilityToWorkOther: null,
-      notHopingToWorkReasons: null,
-      notHopingToWorkOtherReason: null,
+      affectAbilityToWorkOther: undefined,
+      notHopingToWorkReasons: undefined,
+      notHopingToWorkOtherReason: undefined,
     },
     previousWorkExperiences: {
       hasWorkedBefore:
@@ -39,7 +39,7 @@ const aCreateLongQuestionSetInduction = (options?: {
           ? [
               {
                 experienceType: TypeOfWorkExperienceValue.CONSTRUCTION,
-                experienceTypeOther: null,
+                experienceTypeOther: undefined,
                 role: 'General labourer',
                 details: 'Groundwork and basic block work and bricklaying',
               },
@@ -56,12 +56,12 @@ const aCreateLongQuestionSetInduction = (options?: {
       interests: [
         {
           workType: WorkInterestsValue.RETAIL,
-          workTypeOther: null,
-          role: null,
+          workTypeOther: undefined,
+          role: undefined,
         },
         {
           workType: WorkInterestsValue.CONSTRUCTION,
-          workTypeOther: null,
+          workTypeOther: undefined,
           role: 'General labourer',
         },
         {
@@ -75,16 +75,16 @@ const aCreateLongQuestionSetInduction = (options?: {
       skills:
         !options || options.hasSkills === null || options.hasSkills === undefined || options.hasSkills === true
           ? [
-              { skillType: SkillsValue.TEAMWORK, skillTypeOther: null },
-              { skillType: SkillsValue.WILLINGNESS_TO_LEARN, skillTypeOther: null },
+              { skillType: SkillsValue.TEAMWORK, skillTypeOther: undefined },
+              { skillType: SkillsValue.WILLINGNESS_TO_LEARN, skillTypeOther: undefined },
               { skillType: SkillsValue.OTHER, skillTypeOther: 'Tenacity' },
             ]
           : [],
       interests:
         !options || options.hasInterests === null || options.hasInterests === undefined || options.hasInterests === true
           ? [
-              { interestType: PersonalInterestsValue.CREATIVE, interestTypeOther: null },
-              { interestType: PersonalInterestsValue.DIGITAL, interestTypeOther: null },
+              { interestType: PersonalInterestsValue.CREATIVE, interestTypeOther: undefined },
+              { interestType: PersonalInterestsValue.DIGITAL, interestTypeOther: undefined },
               { interestType: PersonalInterestsValue.OTHER, interestTypeOther: 'Renewable energy' },
             ]
           : [],
@@ -117,24 +117,24 @@ const aCreateShortQuestionSetInduction = (options?: {
     ...baseCreateInductionRequestTemplate(),
     workOnRelease: {
       hopingToWork: options?.hopingToGetWork || HopingToGetWorkValue.NO,
-      affectAbilityToWork: null,
-      affectAbilityToWorkOther: null,
+      affectAbilityToWork: undefined,
+      affectAbilityToWorkOther: undefined,
       notHopingToWorkReasons: [ReasonToNotGetWorkValue.HEALTH, ReasonToNotGetWorkValue.OTHER],
       notHopingToWorkOtherReason: 'Will be of retirement age at release',
     },
     inPrisonInterests: {
       inPrisonWorkInterests: [
-        { workType: InPrisonWorkValue.CLEANING_AND_HYGIENE, workTypeOther: null },
+        { workType: InPrisonWorkValue.CLEANING_AND_HYGIENE, workTypeOther: undefined },
         { workType: InPrisonWorkValue.OTHER, workTypeOther: 'Gardening and grounds keeping' },
       ],
       inPrisonTrainingInterests: [
-        { trainingType: InPrisonEducationValue.FORKLIFT_DRIVING, trainingTypeOther: null },
-        { trainingType: InPrisonEducationValue.CATERING, trainingTypeOther: null },
+        { trainingType: InPrisonEducationValue.FORKLIFT_DRIVING, trainingTypeOther: undefined },
+        { trainingType: InPrisonEducationValue.CATERING, trainingTypeOther: undefined },
         { trainingType: InPrisonEducationValue.OTHER, trainingTypeOther: 'Advanced origami' },
       ],
     },
     previousQualifications: {
-      educationLevel: null,
+      educationLevel: undefined,
       qualifications: [
         {
           subject: 'English',


### PR DESCRIPTION
This PR adds a mapper to convert a `CiagPlan` into a `CreateOrUpdateInductionDto`. Similarly to the `CiagPlanMapper`, this currently isn't being used, but I plan to call it from the `CheckYourAnswersController` in a following PR (though I'd like to discuss our approach for this first).

Note that I'm only interested in the "create" journey here, so I'm not doing anything with the `reference` field in each relevant object.