### PR TITLE
RR-597 - Create Induction via new `/inductions` API

### DIFF
--- a/integration_tests/mockApis/ciagApi.ts
+++ b/integration_tests/mockApis/ciagApi.ts
@@ -1,20 +1,5 @@
 import { stubFor } from './wiremock'
 
-const createCiagPlan = (id = 'G6115VJ') =>
-  stubFor({
-    request: {
-      method: 'POST',
-      urlPattern: `/ciag/induction/${id}`,
-    },
-    response: {
-      status: 200,
-      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-      jsonBody: {
-        offenderId: id,
-      },
-    },
-  })
-
 const updateCiagPlan = (id = 'G6115VJ') =>
   stubFor({
     request: {
@@ -30,7 +15,4 @@ const updateCiagPlan = (id = 'G6115VJ') =>
     },
   })
 
-export default {
-  createCiagPlan,
-  updateCiagPlan,
-}
+export default { updateCiagPlan }

--- a/server/data/mappers/createOrUpdateInductionDtoMapper.ts
+++ b/server/data/mappers/createOrUpdateInductionDtoMapper.ts
@@ -28,7 +28,7 @@ const toCreateOrUpdatePreviousQualificationsDto = (ciagPlan: CiagPlan) => {
   return ciagPlan.qualificationsAndTraining
     ? {
         educationLevel: ciagPlan.qualificationsAndTraining.educationLevel,
-        qualifications: ciagPlan.qualificationsAndTraining.qualifications.map(qualification => {
+        qualifications: ciagPlan.qualificationsAndTraining.qualifications?.map(qualification => {
           return {
             subject: qualification.subject,
             grade: qualification.grade,
@@ -51,7 +51,7 @@ const toCreateOrUpdatePreviousWorkExperiencesDto = (ciagPlan: CiagPlan) => {
   return ciagPlan.workExperience
     ? {
         hasWorkedBefore: ciagPlan.workExperience.hasWorkedBefore,
-        experiences: ciagPlan.workExperience.workExperience.map(experience => {
+        experiences: ciagPlan.workExperience.workExperience?.map(experience => {
           return {
             experienceType: experience.typeOfWorkExperience,
             experienceTypeOther:
@@ -68,13 +68,13 @@ const toCreateOrUpdatePreviousWorkExperiencesDto = (ciagPlan: CiagPlan) => {
 const toCreateOrUpdateInPrisonInterestsDto = (ciagPlan: CiagPlan) => {
   return ciagPlan.inPrisonInterests
     ? {
-        inPrisonWorkInterests: ciagPlan.inPrisonInterests.inPrisonWork.map(workInterest => {
+        inPrisonWorkInterests: ciagPlan.inPrisonInterests.inPrisonWork?.map(workInterest => {
           return {
             workType: workInterest,
             workTypeOther: workInterest === 'OTHER' ? ciagPlan.inPrisonInterests.inPrisonWorkOther : undefined,
           }
         }),
-        inPrisonTrainingInterests: ciagPlan.inPrisonInterests.inPrisonEducation.map(trainingInterest => {
+        inPrisonTrainingInterests: ciagPlan.inPrisonInterests.inPrisonEducation?.map(trainingInterest => {
           return {
             trainingType: trainingInterest,
             trainingTypeOther:
@@ -87,13 +87,13 @@ const toCreateOrUpdateInPrisonInterestsDto = (ciagPlan: CiagPlan) => {
 const toCreateOrUpdatePersonalSkillsAndInterestsDto = (ciagPlan: CiagPlan) => {
   return ciagPlan.skillsAndInterests
     ? {
-        skills: ciagPlan.skillsAndInterests.skills.map(skill => {
+        skills: ciagPlan.skillsAndInterests.skills?.map(skill => {
           return {
             skillType: skill,
             skillTypeOther: skill === 'OTHER' ? ciagPlan.skillsAndInterests.skillsOther : undefined,
           }
         }),
-        interests: ciagPlan.skillsAndInterests.personalInterests.map(interest => {
+        interests: ciagPlan.skillsAndInterests.personalInterests?.map(interest => {
           return {
             interestType: interest,
             interestTypeOther: interest === 'OTHER' ? ciagPlan.skillsAndInterests.personalInterestsOther : undefined,
@@ -105,7 +105,7 @@ const toCreateOrUpdatePersonalSkillsAndInterestsDto = (ciagPlan: CiagPlan) => {
 const toCreateOrUpdateFutureWorkInterestsDto = (ciagPlan: CiagPlan) => {
   return ciagPlan.workExperience?.workInterests
     ? {
-        interests: ciagPlan.workExperience.workInterests.workInterests.map(interest => {
+        interests: ciagPlan.workExperience.workInterests.workInterests?.map(interest => {
           return {
             workType: interest,
             workTypeOther: interest === 'OTHER' ? ciagPlan.workExperience.workInterests.workInterestsOther : undefined,

--- a/server/routes/createPlan/checkYourAnswers/checkYourAnswersController.ts
+++ b/server/routes/createPlan/checkYourAnswers/checkYourAnswersController.ts
@@ -10,7 +10,7 @@ import FlowUpdateCiagPlanRequest from '../../../data/ciagApi/models/flowUpdateCi
 import InductionService from '../../../services/inductionService'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import CiagPlan from '../../../data/ciagApi/interfaces/ciagPlan'
-import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
+import YesNoValue from '../../../enums/yesNoValue'
 
 export default class CheckYourAnswersController {
   constructor(
@@ -51,35 +51,40 @@ export default class CheckYourAnswersController {
       const record = getSessionData(req, ['createPlan', id])
       const newCiagPlan: CiagPlan = {
         offenderId: id,
-        desireToWork: record.hopingToWork === HopingToGetWorkValue.YES,
+        desireToWork: record.hopingToWork === YesNoValue.YES,
         hopingToGetWork: record.hopingToGetWork,
         reasonToNotGetWork: record.reasonToNotGetWork,
         reasonToNotGetWorkOther: record.reasonToNotGetWorkOther,
         abilityToWork: record.abilityToWork,
         abilityToWorkOther: record.abilityToWorkOther,
-        workExperience: {
-          hasWorkedBefore: record.hasWorkedBefore,
-          typeOfWorkExperience: record.typeOfWorkExperience,
-          typeOfWorkExperienceOther: record.typeOfWorkExperienceOther,
-          workExperience: record.workExperience,
-          modifiedBy: undefined,
-          modifiedDateTime: undefined,
-          workInterests: {
-            workInterests: record.workInterests,
-            workInterestsOther: record.workInterestsOther,
-            particularJobInterests: record.particularJobInterests,
-            modifiedBy: undefined,
-            modifiedDateTime: undefined,
-          },
-        },
-        skillsAndInterests: {
-          skills: record.skills,
-          skillsOther: record.skillsOther,
-          personalInterests: record.personalInterests,
-          personalInterestsOther: record.personalInterestsOther,
-          modifiedBy: undefined,
-          modifiedDateTime: undefined,
-        },
+        workExperience: record.hasWorkedBefore
+          ? {
+              hasWorkedBefore: record.hasWorkedBefore === YesNoValue.YES,
+              typeOfWorkExperience: record.typeOfWorkExperience,
+              typeOfWorkExperienceOther: record.typeOfWorkExperienceOther,
+              workExperience: record.workExperience,
+              modifiedBy: undefined,
+              modifiedDateTime: undefined,
+              workInterests: {
+                workInterests: record.workInterests,
+                workInterestsOther: record.workInterestsOther,
+                particularJobInterests: record.particularJobInterests,
+                modifiedBy: undefined,
+                modifiedDateTime: undefined,
+              },
+            }
+          : undefined,
+        skillsAndInterests:
+          record.skills && record.personalInterests
+            ? {
+                skills: record.skills,
+                skillsOther: record.skillsOther,
+                personalInterests: record.personalInterests,
+                personalInterestsOther: record.personalInterestsOther,
+                modifiedBy: undefined,
+                modifiedDateTime: undefined,
+              }
+            : undefined,
         qualificationsAndTraining: {
           educationLevel: record.educationLevel,
           qualifications: record.qualifications,
@@ -88,14 +93,17 @@ export default class CheckYourAnswersController {
           modifiedBy: undefined,
           modifiedDateTime: undefined,
         },
-        inPrisonInterests: {
-          inPrisonWork: record.inPrisonWork,
-          inPrisonWorkOther: record.inPrisonWorkOther,
-          inPrisonEducation: record.inPrisonEducation,
-          inPrisonEducationOther: record.inPrisonEducationOther,
-          modifiedBy: undefined,
-          modifiedDateTime: undefined,
-        },
+        inPrisonInterests:
+          record.inPrisonWork && record.inPrisonEducation
+            ? {
+                inPrisonWork: record.inPrisonWork,
+                inPrisonWorkOther: record.inPrisonWorkOther,
+                inPrisonEducation: record.inPrisonEducation,
+                inPrisonEducationOther: record.inPrisonEducationOther,
+                modifiedBy: undefined,
+                modifiedDateTime: undefined,
+              }
+            : undefined,
         prisonId: prisoner.prisonId,
         prisonName: prisoner.prisonName,
         createdBy: undefined,

--- a/server/routes/createPlan/checkYourAnswers/index.ts
+++ b/server/routes/createPlan/checkYourAnswers/index.ts
@@ -5,7 +5,7 @@ import type { Services } from '../../../services'
 import CheckYourAnswersController from './checkYourAnswersController'
 
 export default (router: Router, services: Services) => {
-  const controller = new CheckYourAnswersController(services.ciagService)
+  const controller = new CheckYourAnswersController(services.ciagService, services.inductionService)
 
   router.get(
     '/plan/create/:id/check-your-answers',


### PR DESCRIPTION
This PR makes the required changes to `CheckYourAnswersController` to create an Induction using the new `/inductions` API (via the `InductionService` and `EducationAndWorkPlanClient`), rather than via the legacy CIAG API. This is feature toggled, so that we only enable it in production once we're sufficiently confident to do so.