### PR TITLE
RR-527 - Service and mapper to update an Induction

### DIFF
--- a/server/@types/educationAndWorkPlanApiClient/index.d.ts
+++ b/server/@types/educationAndWorkPlanApiClient/index.d.ts
@@ -18,4 +18,13 @@ declare module 'educationAndWorkPlanApiClient' {
   export type CreateInPrisonInterestsRequest = components['schemas']['CreateInPrisonInterestsRequest']
   export type CreatePersonalSkillsAndInterestsRequest = components['schemas']['CreatePersonalSkillsAndInterestsRequest']
   export type CreateFutureWorkInterestsRequest = components['schemas']['CreateFutureWorkInterestsRequest']
+
+  export type UpdateInductionRequest = components['schemas']['UpdateInductionRequest']
+  export type UpdateWorkOnReleaseRequest = components['schemas']['UpdateWorkOnReleaseRequest']
+  export type UpdatePreviousQualificationsRequest = components['schemas']['UpdatePreviousQualificationsRequest']
+  export type UpdatePreviousTrainingRequest = components['schemas']['UpdatePreviousTrainingRequest']
+  export type UpdatePreviousWorkExperiencesRequest = components['schemas']['UpdatePreviousWorkExperiencesRequest']
+  export type UpdateInPrisonInterestsRequest = components['schemas']['UpdateInPrisonInterestsRequest']
+  export type UpdatePersonalSkillsAndInterestsRequest = components['schemas']['UpdatePersonalSkillsAndInterestsRequest']
+  export type UpdateFutureWorkInterestsRequest = components['schemas']['UpdateFutureWorkInterestsRequest']
 }

--- a/server/data/educationAndWorkPlanClient.test.ts
+++ b/server/data/educationAndWorkPlanClient.test.ts
@@ -3,6 +3,7 @@ import config from '../config'
 import EducationAndWorkPlanClient from './educationAndWorkPlanClient'
 import { aShortQuestionSetInduction } from '../testsupport/inductionResponseTestDataBuilder'
 import { aCreateLongQuestionSetInduction } from '../testsupport/createInductionRequestTestDataBuilder'
+import { anUpdateLongQuestionSetInduction } from '../testsupport/updateInductionRequestTestDataBuilder'
 
 describe('educationAndWorkPlanClient', () => {
   const educationAndWorkPlanClient = new EducationAndWorkPlanClient()
@@ -111,6 +112,45 @@ describe('educationAndWorkPlanClient', () => {
       // When
       try {
         await educationAndWorkPlanClient.createInduction(prisonNumber, createRequest, systemToken)
+      } catch (e) {
+        // Then
+        expect(nock.isDone()).toBe(true)
+        expect(e.status).toEqual(500)
+        expect(e.data).toEqual(expectedResponseBody)
+      }
+    })
+  })
+
+  describe('updateInduction', () => {
+    it('should update Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+      const updateRequest = anUpdateLongQuestionSetInduction()
+      educationAndWorkPlanApi.put(`/inductions/${prisonNumber}`, updateRequest).reply(201)
+
+      // When
+      await educationAndWorkPlanClient.updateInduction(prisonNumber, updateRequest, systemToken)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it('should not update Induction given API returns error response', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+      const updateRequest = anUpdateLongQuestionSetInduction()
+      const expectedResponseBody = {
+        status: 500,
+        userMessage: 'An unexpected error occurred',
+        developerMessage: 'An unexpected error occurred',
+      }
+      educationAndWorkPlanApi.put(`/inductions/${prisonNumber}`, updateRequest).reply(500, expectedResponseBody)
+
+      // When
+      try {
+        await educationAndWorkPlanClient.updateInduction(prisonNumber, updateRequest, systemToken)
       } catch (e) {
         // Then
         expect(nock.isDone()).toBe(true)

--- a/server/data/educationAndWorkPlanClient.ts
+++ b/server/data/educationAndWorkPlanClient.ts
@@ -1,4 +1,4 @@
-import type { CreateInductionRequest, InductionResponse } from 'educationAndWorkPlanApiClient'
+import type { CreateInductionRequest, InductionResponse, UpdateInductionRequest } from 'educationAndWorkPlanApiClient'
 import RestClient from './restClient'
 import config from '../config'
 
@@ -17,6 +17,13 @@ export default class EducationAndWorkPlanClient {
   async getInduction(prisonNumber: string, token: string): Promise<InductionResponse> {
     return EducationAndWorkPlanClient.restClient(token).get({
       path: `/inductions/${prisonNumber}`,
+    })
+  }
+
+  async updateInduction(prisonNumber: string, updateRequest: UpdateInductionRequest, token: string): Promise<unknown> {
+    return EducationAndWorkPlanClient.restClient(token).put({
+      path: `/inductions/${prisonNumber}`,
+      data: updateRequest,
     })
   }
 }

--- a/server/data/mappers/updateInductionRequestMapper.test.ts
+++ b/server/data/mappers/updateInductionRequestMapper.test.ts
@@ -1,0 +1,18 @@
+import type { CreateOrUpdateInductionDto } from 'dto'
+import toUpdateInductionRequest from './updateInductionRequestMapper'
+import { anUpdateLongQuestionSetInductionDto } from '../../testsupport/updateInductionDtoTestDataBuilder'
+import { anUpdateLongQuestionSetInduction } from '../../testsupport/updateInductionRequestTestDataBuilder'
+
+describe('updateInductionMapper', () => {
+  it('should map to UpdateInductionRequest given a valid DTO', () => {
+    // Given
+    const updateInductionDto: CreateOrUpdateInductionDto = anUpdateLongQuestionSetInductionDto()
+    const expectedUpdateInductionRequest = anUpdateLongQuestionSetInduction()
+
+    // When
+    const actual = toUpdateInductionRequest(updateInductionDto)
+
+    // Then
+    expect(actual).toEqual(expectedUpdateInductionRequest)
+  })
+})

--- a/server/data/mappers/updateInductionRequestMapper.ts
+++ b/server/data/mappers/updateInductionRequestMapper.ts
@@ -1,0 +1,8 @@
+import type { UpdateInductionRequest } from 'educationAndWorkPlanApiClient'
+import type { CreateOrUpdateInductionDto } from 'dto'
+
+const toUpdateInductionRequest = (updateInductionDto: CreateOrUpdateInductionDto): UpdateInductionRequest => {
+  return { ...updateInductionDto }
+}
+
+export default toUpdateInductionRequest

--- a/server/services/inductionService.ts
+++ b/server/services/inductionService.ts
@@ -3,6 +3,7 @@ import logger from '../../logger'
 import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
 import toCreateInductionRequest from '../data/mappers/createInductionRequestMapper'
 import toInductionDto from '../data/mappers/inductionDtoMapper'
+import toUpdateInductionRequest from '../data/mappers/updateInductionRequestMapper'
 
 export default class InductionService {
   constructor(private readonly educationAndWorkPlanClient: EducationAndWorkPlanClient) {}
@@ -39,6 +40,20 @@ export default class InductionService {
       return await this.educationAndWorkPlanClient.createInduction(prisonNumber, request, token)
     } catch (error) {
       logger.error(`Error creating Induction within the Education And Work Plan API`, error)
+      throw error
+    }
+  }
+
+  async updateInduction(
+    prisonNumber: string,
+    updateInductionDto: CreateOrUpdateInductionDto,
+    token: string,
+  ): Promise<unknown> {
+    try {
+      const request = toUpdateInductionRequest(updateInductionDto)
+      return await this.educationAndWorkPlanClient.updateInduction(prisonNumber, request, token)
+    } catch (error) {
+      logger.error(`Error updating Induction within the Education And Work Plan API`, error)
       throw error
     }
   }

--- a/server/testsupport/updateInductionDtoTestDataBuilder.ts
+++ b/server/testsupport/updateInductionDtoTestDataBuilder.ts
@@ -1,0 +1,169 @@
+import type { CreateOrUpdateInductionDto } from 'dto'
+import HopingToGetWorkValue from '../enums/hopingToGetWorkValue'
+import AbilityToWorkValue from '../enums/abilityToWorkValue'
+import TypeOfWorkExperienceValue from '../enums/typeOfWorkExperienceValue'
+import WorkInterestsValue from '../enums/workInterestsValue'
+import SkillsValue from '../enums/skillsValue'
+import PersonalInterestsValue from '../enums/personalInterestsValue'
+import EducationLevelValue from '../enums/educationLevelValue'
+import QualificationLevelValue from '../enums/qualificationLevelValue'
+import AdditionalTrainingValue from '../enums/additionalTrainingValue'
+import ReasonToNotGetWorkValue from '../enums/reasonToNotGetWorkValue'
+import InPrisonWorkValue from '../enums/inPrisonWorkValue'
+import InPrisonEducationValue from '../enums/inPrisonEducationValue'
+
+const anUpdateLongQuestionSetInductionDto = (options?: {
+  hasWorkedBefore?: boolean
+  hasSkills?: boolean
+  hasInterests?: boolean
+}): CreateOrUpdateInductionDto => {
+  return {
+    ...baseDtoTemplate(),
+    workOnRelease: {
+      reference: '2f4cfa00-40ae-4859-9f96-d7576f989a95',
+      hopingToWork: HopingToGetWorkValue.YES,
+      affectAbilityToWork: [AbilityToWorkValue.HEALTH_ISSUES],
+      affectAbilityToWorkOther: undefined,
+      notHopingToWorkReasons: undefined,
+      notHopingToWorkOtherReason: undefined,
+    },
+    previousWorkExperiences: {
+      reference: '91e8634a-8ddc-40ee-8854-f099e3e0440f',
+      hasWorkedBefore:
+        !options || options.hasWorkedBefore === null || options.hasWorkedBefore === undefined
+          ? true
+          : options.hasWorkedBefore,
+      experiences:
+        !options ||
+        options.hasWorkedBefore === null ||
+        options.hasWorkedBefore === undefined ||
+        options.hasWorkedBefore === true
+          ? [
+              {
+                experienceType: TypeOfWorkExperienceValue.OTHER,
+                experienceTypeOther: 'Retail delivery',
+                role: 'Milkman',
+                details: 'Self employed franchise operator delivering milk and associated diary products.',
+              },
+            ]
+          : [],
+    },
+    futureWorkInterests: {
+      reference: 'b01c4344-dbbf-417e-8b90-17d19062dfa6',
+      interests: [
+        {
+          workType: WorkInterestsValue.BEAUTY,
+          workTypeOther: undefined,
+          role: undefined,
+        },
+        {
+          workType: WorkInterestsValue.OTHER,
+          workTypeOther: 'Film, TV and media',
+          role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+        },
+      ],
+    },
+    personalSkillsAndInterests: {
+      reference: '2bb27e5e-2d49-4502-8c08-629099561c8a',
+      skills:
+        !options || options.hasSkills === null || options.hasSkills === undefined || options.hasSkills === true
+          ? [
+              { skillType: SkillsValue.TEAMWORK, skillTypeOther: undefined },
+              { skillType: SkillsValue.OTHER, skillTypeOther: 'Tenacity' },
+            ]
+          : [],
+      interests:
+        !options || options.hasInterests === null || options.hasInterests === undefined || options.hasInterests === true
+          ? [
+              { interestType: PersonalInterestsValue.DIGITAL, interestTypeOther: undefined },
+              { interestType: PersonalInterestsValue.OTHER, interestTypeOther: 'Renewable energy' },
+            ]
+          : [],
+    },
+    previousQualifications: {
+      reference: `17f34868-99c9-40ed-b923-ca273cacc096`,
+      educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
+      qualifications: [
+        {
+          subject: 'Pottery',
+          grade: 'C',
+          level: QualificationLevelValue.LEVEL_4,
+        },
+        {
+          subject: 'Maths',
+          grade: 'B',
+          level: QualificationLevelValue.LEVEL_4,
+        },
+      ],
+    },
+    previousTraining: {
+      reference: '68f47a63-6e4f-4645-80e7-5757be5f6958',
+      trainingTypes: [AdditionalTrainingValue.FIRST_AID_CERTIFICATE, AdditionalTrainingValue.OTHER],
+      trainingTypeOther: 'Advanced origami',
+    },
+  }
+}
+
+const anUpdateShortQuestionSetInductionDto = (options?: {
+  hopingToGetWork?: HopingToGetWorkValue.NO | HopingToGetWorkValue.NOT_SURE
+}): CreateOrUpdateInductionDto => {
+  return {
+    ...baseDtoTemplate(),
+    workOnRelease: {
+      reference: '2f4cfa00-40ae-4859-9f96-d7576f989a95',
+      hopingToWork: options?.hopingToGetWork || HopingToGetWorkValue.NO,
+      affectAbilityToWork: undefined,
+      affectAbilityToWorkOther: undefined,
+      notHopingToWorkReasons: [ReasonToNotGetWorkValue.OTHER],
+      notHopingToWorkOtherReason: 'Will be of retirement age at release',
+    },
+    inPrisonInterests: {
+      reference: 'fd6df985-2b77-4f64-a860-f37389fa4dd3',
+      inPrisonWorkInterests: [
+        { workType: InPrisonWorkValue.CLEANING_AND_HYGIENE, workTypeOther: undefined },
+        { workType: InPrisonWorkValue.OTHER, workTypeOther: 'Gardening and grounds keeping' },
+      ],
+      inPrisonTrainingInterests: [
+        { trainingType: InPrisonEducationValue.FORKLIFT_DRIVING, trainingTypeOther: undefined },
+        { trainingType: InPrisonEducationValue.OTHER, trainingTypeOther: 'Advanced origami' },
+      ],
+    },
+    previousQualifications: {
+      reference: '2f47cae9-9310-4da5-8984-3577be9ce54d',
+      educationLevel: undefined,
+      qualifications: [
+        {
+          subject: 'English',
+          grade: 'B',
+          level: QualificationLevelValue.LEVEL_6,
+        },
+        {
+          subject: 'Maths',
+          grade: 'A*',
+          level: QualificationLevelValue.LEVEL_6,
+        },
+      ],
+    },
+    previousTraining: {
+      reference: '8ac71798-100e-4652-abbc-5604f231499e',
+      trainingTypes: [AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE, AdditionalTrainingValue.OTHER],
+      trainingTypeOther: 'Beginners cookery for IT professionals',
+    },
+  }
+}
+
+const baseDtoTemplate = (): CreateOrUpdateInductionDto => {
+  return {
+    reference: 'b32c7ad6-86a7-45a9-bd63-4bd7cf1ff46f',
+    prisonId: 'BXI',
+    workOnRelease: undefined,
+    previousQualifications: undefined,
+    previousTraining: undefined,
+    previousWorkExperiences: undefined,
+    inPrisonInterests: undefined,
+    personalSkillsAndInterests: undefined,
+    futureWorkInterests: undefined,
+  }
+}
+
+export { anUpdateLongQuestionSetInductionDto, anUpdateShortQuestionSetInductionDto }

--- a/server/testsupport/updateInductionRequestTestDataBuilder.ts
+++ b/server/testsupport/updateInductionRequestTestDataBuilder.ts
@@ -1,0 +1,169 @@
+import type { UpdateInductionRequest } from 'educationAndWorkPlanApiClient'
+import SkillsValue from '../enums/skillsValue'
+import PersonalInterestsValue from '../enums/personalInterestsValue'
+import HopingToGetWorkValue from '../enums/hopingToGetWorkValue'
+import AbilityToWorkValue from '../enums/abilityToWorkValue'
+import TypeOfWorkExperienceValue from '../enums/typeOfWorkExperienceValue'
+import WorkInterestsValue from '../enums/workInterestsValue'
+import EducationLevelValue from '../enums/educationLevelValue'
+import QualificationLevelValue from '../enums/qualificationLevelValue'
+import AdditionalTrainingValue from '../enums/additionalTrainingValue'
+import ReasonToNotGetWorkValue from '../enums/reasonToNotGetWorkValue'
+import InPrisonWorkValue from '../enums/inPrisonWorkValue'
+import InPrisonEducationValue from '../enums/inPrisonEducationValue'
+
+const anUpdateLongQuestionSetInduction = (options?: {
+  hasWorkedBefore?: boolean
+  hasSkills?: boolean
+  hasInterests?: boolean
+}): UpdateInductionRequest => {
+  return {
+    ...baseUpdateInductionRequestTemplate(),
+    workOnRelease: {
+      reference: '2f4cfa00-40ae-4859-9f96-d7576f989a95',
+      hopingToWork: HopingToGetWorkValue.YES,
+      affectAbilityToWork: [AbilityToWorkValue.HEALTH_ISSUES],
+      affectAbilityToWorkOther: undefined,
+      notHopingToWorkReasons: undefined,
+      notHopingToWorkOtherReason: undefined,
+    },
+    previousWorkExperiences: {
+      reference: '91e8634a-8ddc-40ee-8854-f099e3e0440f',
+      hasWorkedBefore:
+        !options || options.hasWorkedBefore === null || options.hasWorkedBefore === undefined
+          ? true
+          : options.hasWorkedBefore,
+      experiences:
+        !options ||
+        options.hasWorkedBefore === null ||
+        options.hasWorkedBefore === undefined ||
+        options.hasWorkedBefore === true
+          ? [
+              {
+                experienceType: TypeOfWorkExperienceValue.OTHER,
+                experienceTypeOther: 'Retail delivery',
+                role: 'Milkman',
+                details: 'Self employed franchise operator delivering milk and associated diary products.',
+              },
+            ]
+          : [],
+    },
+    futureWorkInterests: {
+      reference: 'b01c4344-dbbf-417e-8b90-17d19062dfa6',
+      interests: [
+        {
+          workType: WorkInterestsValue.BEAUTY,
+          workTypeOther: undefined,
+          role: undefined,
+        },
+        {
+          workType: WorkInterestsValue.OTHER,
+          workTypeOther: 'Film, TV and media',
+          role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+        },
+      ],
+    },
+    personalSkillsAndInterests: {
+      reference: '2bb27e5e-2d49-4502-8c08-629099561c8a',
+      skills:
+        !options || options.hasSkills === null || options.hasSkills === undefined || options.hasSkills === true
+          ? [
+              { skillType: SkillsValue.TEAMWORK, skillTypeOther: undefined },
+              { skillType: SkillsValue.OTHER, skillTypeOther: 'Tenacity' },
+            ]
+          : [],
+      interests:
+        !options || options.hasInterests === null || options.hasInterests === undefined || options.hasInterests === true
+          ? [
+              { interestType: PersonalInterestsValue.DIGITAL, interestTypeOther: undefined },
+              { interestType: PersonalInterestsValue.OTHER, interestTypeOther: 'Renewable energy' },
+            ]
+          : [],
+    },
+    previousQualifications: {
+      reference: `17f34868-99c9-40ed-b923-ca273cacc096`,
+      educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
+      qualifications: [
+        {
+          subject: 'Pottery',
+          grade: 'C',
+          level: QualificationLevelValue.LEVEL_4,
+        },
+        {
+          subject: 'Maths',
+          grade: 'B',
+          level: QualificationLevelValue.LEVEL_4,
+        },
+      ],
+    },
+    previousTraining: {
+      reference: '68f47a63-6e4f-4645-80e7-5757be5f6958',
+      trainingTypes: [AdditionalTrainingValue.FIRST_AID_CERTIFICATE, AdditionalTrainingValue.OTHER],
+      trainingTypeOther: 'Advanced origami',
+    },
+  }
+}
+
+const anUpdateShortQuestionSetInduction = (options?: {
+  hopingToGetWork?: HopingToGetWorkValue.NO | HopingToGetWorkValue.NOT_SURE
+}): UpdateInductionRequest => {
+  return {
+    ...baseUpdateInductionRequestTemplate(),
+    workOnRelease: {
+      reference: '2f4cfa00-40ae-4859-9f96-d7576f989a95',
+      hopingToWork: options?.hopingToGetWork || HopingToGetWorkValue.NO,
+      affectAbilityToWork: undefined,
+      affectAbilityToWorkOther: undefined,
+      notHopingToWorkReasons: [ReasonToNotGetWorkValue.OTHER],
+      notHopingToWorkOtherReason: 'Will be of retirement age at release',
+    },
+    inPrisonInterests: {
+      reference: 'fd6df985-2b77-4f64-a860-f37389fa4dd3',
+      inPrisonWorkInterests: [
+        { workType: InPrisonWorkValue.CLEANING_AND_HYGIENE, workTypeOther: undefined },
+        { workType: InPrisonWorkValue.OTHER, workTypeOther: 'Gardening and grounds keeping' },
+      ],
+      inPrisonTrainingInterests: [
+        { trainingType: InPrisonEducationValue.FORKLIFT_DRIVING, trainingTypeOther: undefined },
+        { trainingType: InPrisonEducationValue.OTHER, trainingTypeOther: 'Advanced origami' },
+      ],
+    },
+    previousQualifications: {
+      reference: '2f47cae9-9310-4da5-8984-3577be9ce54d',
+      educationLevel: undefined,
+      qualifications: [
+        {
+          subject: 'English',
+          grade: 'B',
+          level: QualificationLevelValue.LEVEL_6,
+        },
+        {
+          subject: 'Maths',
+          grade: 'A*',
+          level: QualificationLevelValue.LEVEL_6,
+        },
+      ],
+    },
+    previousTraining: {
+      reference: '8ac71798-100e-4652-abbc-5604f231499e',
+      trainingTypes: [AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE, AdditionalTrainingValue.OTHER],
+      trainingTypeOther: 'Beginners cookery for IT professionals',
+    },
+  }
+}
+
+const baseUpdateInductionRequestTemplate = (): UpdateInductionRequest => {
+  return {
+    reference: 'b32c7ad6-86a7-45a9-bd63-4bd7cf1ff46f',
+    prisonId: 'BXI',
+    workOnRelease: undefined,
+    previousQualifications: undefined,
+    previousTraining: undefined,
+    previousWorkExperiences: undefined,
+    inPrisonInterests: undefined,
+    personalSkillsAndInterests: undefined,
+    futureWorkInterests: undefined,
+  }
+}
+
+export { anUpdateLongQuestionSetInduction, anUpdateShortQuestionSetInduction }


### PR DESCRIPTION
This PR adds the required service, client, mapper and builder methods for updating an Induction via the new `/inductions/{prisonNumber}` endpoint.

I plan to make quite a few changes to the `checkYourAnswersController` in a subsequent PR.