### PR TITLE
RR-570 - Retrieve induction into context prior to POST check-your-answers

### DIFF
--- a/integration_tests/e2e/abilityToWork.cy.ts
+++ b/integration_tests/e2e/abilityToWork.cy.ts
@@ -8,6 +8,9 @@ import ParticularJobInterestsPage from '../pages/particularJobInterests'
 import QualificationsPage from '../pages/qualifications'
 import SkillsPage from '../pages/skills'
 import WorkInterestsPage from '../pages/workInterests'
+import CheckYourAnswersPage from '../pages/checkYourAnswers'
+import Page from '../pages/page'
+import PlpEducationAndTrainingPage from '../pages/plpEducationAndTrainingPage'
 
 context('Ability to work page', () => {
   const longStr = 'x'.repeat(201)
@@ -17,11 +20,14 @@ context('Ability to work page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubPlpPrisonListPageUi')
+    cy.task('stubPlpEducationAndTrainingPageUi', 'G6115VJ')
     cy.task('stubGetFrontEndComponents')
     cy.task('getPrisonerById')
     cy.task('getUserActiveCaseLoad')
     cy.task('stubVerifyToken', true)
     cy.task('getLearnerEducation')
+    cy.task('stubCreateInduction')
+    cy.task('stubRedirectToPlpAfterCreateInduction')
     cy.signIn()
 
     cy.visit('/plan/create/G6115VJ/hoping-to-get-work/new')
@@ -105,7 +111,7 @@ context('Ability to work page', () => {
     abilityToWorkPage.detailsFieldErrorMessage().contains('Reason must be 200 characters or less')
   })
 
-  it('New record - Select LIMITED_BY_OFFENSE - navigates to check-your-answers page', () => {
+  it('New record - Select LIMITED_BY_OFFENSE - submit check-your-answers page and arrive on PLP page', () => {
     const abilityToWorkPage = new AbilityToWorkPage(
       "Is there anything that Daniel Craig feels may affect their ability to work after they're released?",
     )
@@ -114,10 +120,12 @@ context('Ability to work page', () => {
 
     abilityToWorkPage.submitButton().click()
 
-    cy.url().should('include', 'check-your-answers')
+    const checkYourAnswersPage = Page.verifyOnPage(CheckYourAnswersPage)
+    checkYourAnswersPage.submitButton().click()
+    Page.verifyOnPage(PlpEducationAndTrainingPage)
   })
 
-  it('New record - Select OTHER - navigates to check-your-answers page', () => {
+  it('New record - Select OTHER - submit check-your-answers page and arrive on PLP page', () => {
     const abilityToWorkPage = new AbilityToWorkPage(
       "Is there anything that Daniel Craig feels may affect their ability to work after they're released?",
     )
@@ -127,6 +135,8 @@ context('Ability to work page', () => {
 
     abilityToWorkPage.submitButton().click()
 
-    cy.url().should('include', 'check-your-answers')
+    const checkYourAnswersPage = Page.verifyOnPage(CheckYourAnswersPage)
+    checkYourAnswersPage.submitButton().click()
+    Page.verifyOnPage(PlpEducationAndTrainingPage)
   })
 })

--- a/integration_tests/e2e/checkYourAnswersFull.cy.ts
+++ b/integration_tests/e2e/checkYourAnswersFull.cy.ts
@@ -13,6 +13,8 @@ import QualificationDetailsPage from '../pages/qualificationDetails'
 import TypeOfWorkExperiencePage from '../pages/typeOfWorkExperience'
 import JobDetailsPage from '../pages/jobDetails'
 import CheckYourAnswersPage from '../pages/checkYourAnswers'
+import Page from '../pages/page'
+import PlpEducationAndTrainingPage from '../pages/plpEducationAndTrainingPage'
 
 context('Check your answers - Full flow', () => {
   before(() => {
@@ -20,11 +22,14 @@ context('Check your answers - Full flow', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubPlpPrisonListPageUi')
+    cy.task('stubPlpEducationAndTrainingPageUi', 'G6115VJ')
     cy.task('stubGetFrontEndComponents')
     cy.task('getPrisonerById')
     cy.task('getUserActiveCaseLoad')
     cy.task('stubVerifyToken', true)
     cy.task('getLearnerEducation')
+    cy.task('stubCreateInduction')
+    cy.task('stubRedirectToPlpAfterCreateInduction')
     cy.signIn()
 
     cy.visit('/plan/create/G6115VJ/hoping-to-get-work/new')
@@ -131,11 +136,13 @@ context('Check your answers - Full flow', () => {
     abilityToWorkPage.textareaField().type('Some other limitation')
 
     abilityToWorkPage.submitButton().click()
+
+    Page.verifyOnPage(CheckYourAnswersPage)
   })
 
-  it('New record - Full flow - Values have been set correctly, change links work', () => {
-    const checkYourAnswersPage = new CheckYourAnswersPage(
-      "Check and save your answers before adding Daniel Craig's goals",
+  it('New record - Full flow - Values have been set correctly, change links work; page is submitted to the PLP page', () => {
+    let checkYourAnswersPage = new CheckYourAnswersPage(
+      `Check and save your answers before adding Daniel Craig's goals`,
     )
 
     checkYourAnswersPage.hopingToGetWork().contains('Yes')
@@ -221,5 +228,9 @@ context('Check your answers - Full flow', () => {
       "Is there anything that Daniel Craig feels may affect their ability to work after they're released?",
     )
     abilityToWorkPage.backLink().click()
+
+    checkYourAnswersPage = Page.verifyOnPage(CheckYourAnswersPage)
+    checkYourAnswersPage.submitButton().click()
+    Page.verifyOnPage(PlpEducationAndTrainingPage)
   })
 })

--- a/integration_tests/e2e/checkYourAnswersLite.cy.ts
+++ b/integration_tests/e2e/checkYourAnswersLite.cy.ts
@@ -8,6 +8,8 @@ import WantsToAddQualifications from '../pages/wantsToAddQualifications'
 import CheckYourAnswersPage from '../pages/checkYourAnswers'
 import InPrisonWorkPage from '../pages/inPrisonWork'
 import InPrisonEducationPage from '../pages/inPrisonEducation'
+import Page from '../pages/page'
+import PlpEducationAndTrainingPage from '../pages/plpEducationAndTrainingPage'
 
 context('Check your answers - Lite flow', () => {
   beforeEach(() => {
@@ -15,11 +17,14 @@ context('Check your answers - Lite flow', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubPlpPrisonListPageUi')
+    cy.task('stubPlpEducationAndTrainingPageUi', 'G6115VJ')
     cy.task('stubGetFrontEndComponents')
     cy.task('getPrisonerById')
     cy.task('getUserActiveCaseLoad')
     cy.task('stubVerifyToken', true)
     cy.task('getLearnerEducation')
+    cy.task('stubCreateInduction')
+    cy.task('stubRedirectToPlpAfterCreateInduction')
     cy.signIn()
 
     cy.visit('/plan/create/G6115VJ/hoping-to-get-work/new')
@@ -78,11 +83,13 @@ context('Check your answers - Lite flow', () => {
     inPrisonEducationPage.checkboxFieldValue('OTHER').click()
     inPrisonEducationPage.textareaField().type('Some other in prison education')
     inPrisonEducationPage.submitButton().click()
+
+    Page.verifyOnPage(CheckYourAnswersPage)
   })
 
-  it('New record - Lite flow - Values have been set correctly, change links work', () => {
-    const checkYourAnswersPage = new CheckYourAnswersPage(
-      "Check and save your answers before adding Daniel Craig's goals",
+  it('New record - Lite flow - Values have been set correctly, change links work; page is submitted to the PLP page', () => {
+    let checkYourAnswersPage = new CheckYourAnswersPage(
+      `Check and save your answers before adding Daniel Craig's goals`,
     )
 
     checkYourAnswersPage.hopingToGetWork().contains('No')
@@ -131,5 +138,9 @@ context('Check your answers - Lite flow', () => {
       'What type of training and education activities would Daniel Craig like to do in prison?',
     )
     inPrisonEducationPage.backLink().click()
+
+    checkYourAnswersPage = Page.verifyOnPage(CheckYourAnswersPage)
+    checkYourAnswersPage.submitButton().click()
+    Page.verifyOnPage(PlpEducationAndTrainingPage)
   })
 })

--- a/integration_tests/e2e/inPrisonEducation.cy.ts
+++ b/integration_tests/e2e/inPrisonEducation.cy.ts
@@ -4,6 +4,9 @@ import InPrisonEducationPage from '../pages/inPrisonEducation'
 import InPrisonWorkPage from '../pages/inPrisonWork'
 import ReasonToNotGetWork from '../pages/reasonToNotGetWork'
 import WantsToAddQualifications from '../pages/wantsToAddQualifications'
+import Page from '../pages/page'
+import CheckYourAnswersPage from '../pages/checkYourAnswers'
+import PlpEducationAndTrainingPage from '../pages/plpEducationAndTrainingPage'
 
 context('In prison education work page', () => {
   beforeEach(() => {
@@ -11,11 +14,14 @@ context('In prison education work page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubPlpPrisonListPageUi')
+    cy.task('stubPlpEducationAndTrainingPageUi', 'G6115VJ')
     cy.task('stubGetFrontEndComponents')
     cy.task('getPrisonerById')
     cy.task('getUserActiveCaseLoad')
     cy.task('stubVerifyToken', true)
     cy.task('getLearnerEducation')
+    cy.task('stubCreateInduction')
+    cy.task('stubRedirectToPlpAfterCreateInduction')
     cy.signIn()
 
     cy.visit('/plan/create/G6115VJ/hoping-to-get-work/new')
@@ -90,7 +96,7 @@ context('In prison education work page', () => {
     inPrisonEducation.detailsFieldErrorMessage().should('contain', 'Training in prison must be 200 characters or less')
   })
 
-  it('Select OTHER - details entered - navigate to qualifications page', () => {
+  it('Select OTHER - details entered - page is submitted to the PLP page', () => {
     const inPrisonEducation = new InPrisonEducationPage(
       `What type of training and education activities would Daniel Craig like to do in prison?`,
     )
@@ -99,6 +105,8 @@ context('In prison education work page', () => {
     inPrisonEducation.textareaField().clear().type('other details')
     inPrisonEducation.submitButton().click()
 
-    cy.url().should('include', 'check-your-answers')
+    const checkYourAnswersPage = Page.verifyOnPage(CheckYourAnswersPage)
+    checkYourAnswersPage.submitButton().click()
+    Page.verifyOnPage(PlpEducationAndTrainingPage)
   })
 })

--- a/integration_tests/e2e/updateInduction.cy.ts
+++ b/integration_tests/e2e/updateInduction.cy.ts
@@ -1,0 +1,69 @@
+import HopingToGetWorkPage from '../pages/hopingToGetWork'
+import ReasonToNotGetWork from '../pages/reasonToNotGetWork'
+import QualificationsPage from '../pages/qualifications'
+import AdditionalTrainingPage from '../pages/additionalTraining'
+import InPrisonWorkPage from '../pages/inPrisonWork'
+import InPrisonEducationPage from '../pages/inPrisonEducation'
+import Page from '../pages/page'
+import CheckYourAnswersPage from '../pages/checkYourAnswers'
+import PlpWorkAndInterestsPage from '../pages/plpWorkAndInterestsPage'
+
+context(
+  `Update an Induction to change it's question set, resulting going through the whole journey to Check Your Answers and on to PLP`,
+  () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn')
+      cy.task('stubAuthUser')
+      cy.task('stubPlpPrisonListPageUi')
+      cy.task('stubGetFrontEndComponents')
+      cy.task('getPrisonerById')
+      cy.task('getUserActiveCaseLoad')
+      cy.task('stubVerifyToken', true)
+      cy.task('getLearnerEducation')
+      cy.task('updateCiagPlan')
+      cy.task('stubPlpWorkAndInterestsPageUi', 'G6115VJ')
+      cy.signIn()
+    })
+
+    it('should update a long question Induction to short question set', () => {
+      // Given
+      cy.task('stubGetInductionLongQuestionSet')
+      cy.visit('/plan/create/G6115VJ/hoping-to-get-work/update')
+
+      const hopingToGetWorkPage = new HopingToGetWorkPage(`Is Daniel Craig hoping to get work when they're released?`)
+      hopingToGetWorkPage.radioFieldValue('NO').click()
+      hopingToGetWorkPage.submitButton().click()
+
+      const reasonToNotGetWork = new ReasonToNotGetWork('What could stop Daniel Craig working when they are released?')
+      reasonToNotGetWork.checkboxFieldValue('RETIRED').click()
+      reasonToNotGetWork.submitButton().click()
+
+      const qualificationsPage = new QualificationsPage("Daniel Craig's qualifications")
+      qualificationsPage.submitButton().click()
+
+      const additionalTraining = new AdditionalTrainingPage(
+        'Does Daniel Craig have any other training or vocational qualifications?',
+      )
+      additionalTraining.checkboxFieldValue('CSCS_CARD').click()
+      additionalTraining.submitButton().click()
+
+      const inPrisonWorkPage = new InPrisonWorkPage(`What type of work would Daniel Craig like to do in prison?`)
+      inPrisonWorkPage.checkboxFieldValue('WOODWORK_AND_JOINERY').click()
+      inPrisonWorkPage.submitButton().click()
+
+      const inPrisonEducation = new InPrisonEducationPage(
+        `What type of training and education activities would Daniel Craig like to do in prison?`,
+      )
+      inPrisonEducation.checkboxFieldValue('CATERING').click()
+      inPrisonEducation.submitButton().click()
+
+      // When
+      const checkYourAnswersPage = Page.verifyOnPage(CheckYourAnswersPage)
+      checkYourAnswersPage.submitButton().click()
+
+      // Then
+      Page.verifyOnPage(PlpWorkAndInterestsPage)
+    })
+  },
+)

--- a/integration_tests/mockApis/educationAndWorkPlanApi.ts
+++ b/integration_tests/mockApis/educationAndWorkPlanApi.ts
@@ -323,9 +323,36 @@ const stubGetInduction500Error = (prisonNumber = 'G6115VJ'): SuperAgentRequest =
     },
   })
 
+const stubCreateInduction = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPattern: `/inductions/${prisonNumber}`,
+    },
+    response: {
+      status: 201,
+    },
+  })
+
+const stubRedirectToPlpAfterCreateInduction = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/plan/${prisonNumber}/induction-created`,
+    },
+    response: {
+      status: 302,
+      headers: {
+        location: `/plan/${prisonNumber}/view/education-and-training`,
+      },
+    },
+  })
+
 export default {
   stubGetInductionShortQuestionSet,
   stubGetInductionLongQuestionSet,
   stubGetInduction404Error,
   stubGetInduction500Error,
+  stubCreateInduction,
+  stubRedirectToPlpAfterCreateInduction,
 }

--- a/integration_tests/pages/checkYourAnswers.ts
+++ b/integration_tests/pages/checkYourAnswers.ts
@@ -3,6 +3,10 @@ import Page from './page'
 export type PageElement = Cypress.Chainable<JQuery>
 
 export default class CheckYourAnswersPage extends Page {
+  constructor(title?: string) {
+    super(title || 'Check and save your answers')
+  }
+
   manageDetails = (): PageElement => cy.get('[data-qa=manageDetails]')
 
   hopingToGetWork = (): PageElement => cy.get('[data-qa=hopingToGetWork]')


### PR DESCRIPTION
This PR fixes the bug where Updating a CIAG Induction fails by retrieve induction into context prior to `POST check-your-answers`, *but only for the Update journey*

The last part is crucial. My previous attempt at this incorrectly tried to load the Induction when a `POST` was made to `check-your-answers`, but I'd forgotten the fact that the create journey also does a `POST` to `check-your-answers`. Therefore in the create journey, the page resulted in a 404 because the Induction could not be loaded (because it had not been created yet! 🙄 )
We backed that change out quickly .... 😬 

So, this is the same idea of loading the Induction when a `POST` is made to `check-your-answers`, but this time we only do it when its an Update journey.

Because of the implementation it's not really easy/practical to unit test this 😞 , but I have updated the existing cypress integration tests, and also written a new cypress test that performs an Induction update where the question set is changed (long to short) by changing the answer to the question "do they want to work when released from prison"
By changing the question set as part of the update it forces the user through all the question pages again, and crucially for this fix, on to the Check You Answers page. We submit that page (to test the `POST`) and assert we are redirected to PLP
(this level of testing did not exist before)