### PR TITLE
RR-595 - Removed duplicate logger function

### DIFF
--- a/logger.ts
+++ b/logger.ts
@@ -4,6 +4,6 @@ import config from './server/config'
 
 const formatOut = bunyanFormat({ outputMode: 'short', color: !config.production })
 
-const logger = bunyan.createLogger({ name: 'Hmpps Ciag Careers Induction Ui', stream: formatOut, level: 'debug' })
+const logger = bunyan.createLogger({ name: 'HMPPS CIAG Careers Induction UI', stream: formatOut, level: 'debug' })
 
 export default logger

--- a/server/data/legacyRestClient.ts
+++ b/server/data/legacyRestClient.ts
@@ -2,7 +2,7 @@ import superagent, { SuperAgentRequest } from 'superagent'
 import Agent, { HttpsAgent } from 'agentkeepalive'
 import { Readable } from 'stream'
 
-import logger from '../log'
+import logger from '../../logger'
 import type { UnsanitisedError } from '../sanitisedError'
 import sanitiseError from '../sanitisedError'
 import { ApiConfig } from '../config'

--- a/server/data/oauthEnabledClient.test.ts
+++ b/server/data/oauthEnabledClient.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import clientFactory from './oauthEnabledClient'
 import contextProperties from './contextProperties'
-import logger from '../log'
+import logger from '../../logger'
 
 const hostname = 'http://localhost:8080'
 

--- a/server/data/oauthEnabledClient.ts
+++ b/server/data/oauthEnabledClient.ts
@@ -3,7 +3,7 @@ import { Response } from 'express'
 import Agent, { HttpsAgent } from 'agentkeepalive'
 import * as stream from 'stream'
 import { ClientRequest } from 'http'
-import logger from '../log'
+import logger from '../../logger'
 // eslint-disable-next-line import/no-cycle
 import { getHeaders } from './axios-config-decorators'
 

--- a/server/data/token/tokenStore.ts
+++ b/server/data/token/tokenStore.ts
@@ -1,7 +1,7 @@
 import redis from 'redis'
 import { promisify } from 'util'
 
-import logger from '../../log'
+import logger from '../../../logger'
 import config from '../../config'
 
 const createRedisClient = () => {

--- a/server/log.ts
+++ b/server/log.ts
@@ -1,8 +1,0 @@
-import bunyan from 'bunyan'
-import bunyanFormat from 'bunyan-format'
-
-const formatOut = bunyanFormat({ outputMode: 'short', color: true })
-
-const log = bunyan.createLogger({ name: 'Hmpps Ciag Careers Induction Ui', stream: formatOut, level: 'debug' })
-
-export default log

--- a/server/middleware/populateUserDetails.test.ts
+++ b/server/middleware/populateUserDetails.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import populateUserDetails from './populateUserDetails'
 import UserService from '../services/userService'
-import logger from '../log'
+import logger from '../../logger'
 
-jest.mock('../log')
+jest.mock('../../logger')
 jest.mock('../services/userService')
 
 describe('populateUserDetails middleware', () => {

--- a/server/middleware/populateUserDetails.ts
+++ b/server/middleware/populateUserDetails.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express'
-import logger from '../log'
+import logger from '../../logger'
 // eslint-disable-next-line import/no-named-as-default,import/no-named-as-default-member
 import UserService from '../services/userService'
 import getSanitisedError from '../sanitisedError'

--- a/server/services/curiousEsweService.ts
+++ b/server/services/curiousEsweService.ts
@@ -4,7 +4,7 @@ import { HmppsAuthClient } from '../data'
 import clientFactory from '../data/oauthEnabledClient'
 import CuriousApi from '../data/curious/curiousApi'
 import { LearnerLatestAssessment } from '../data/curious/types/Types'
-import log from '../log'
+import logger from '../../logger'
 
 const curiousApi = CuriousApi.create(clientFactory({ baseUrl: config.apis.curiousApi.url }))
 
@@ -21,10 +21,10 @@ export default class CuriousEsweService {
       return await curiousApi.getLearnerLatestAssessments(systemToken, id)
     } catch (e) {
       if (e.status === 404) {
-        log.info(`There is no assessment data for this prisoner: ${id.toUpperCase()}`)
+        logger.info(`There is no assessment data for this prisoner: ${id.toUpperCase()}`)
         return []
       }
-      log.error(`Failed in get learner latest assessment. Reason: ${e.message}`)
+      logger.error(`Failed in get learner latest assessment. Reason: ${e.message}`)
     }
     return null
   }


### PR DESCRIPTION
This PR tidies a little tech debt from the CIAG UI by removing a duplicate logger function (I don't know why the CIAG dev team created it), and refactored uses of it to use the standard logger from the bootstrap template