### PR TITLE
RR-631 Ability to work - use new Induction API

### DIFF
--- a/integration_tests/e2e/updateFunctionalityFull.cy.ts
+++ b/integration_tests/e2e/updateFunctionalityFull.cy.ts
@@ -30,6 +30,7 @@ context('Update functionality - Full flow', () => {
     cy.task('getLearnerEducation')
     cy.task('getPrisonerById', 'A3260DZ')
     cy.task('updateCiagPlan', 'A3260DZ')
+    cy.task('stubUpdateInduction', 'A3260DZ')
     cy.signIn()
   })
 

--- a/integration_tests/e2e/updateFunctionalityLite.cy.ts
+++ b/integration_tests/e2e/updateFunctionalityLite.cy.ts
@@ -22,6 +22,7 @@ context('Update functionality - Lite flow', () => {
     cy.task('getLearnerEducation')
     cy.task('getPrisonerById', 'B79237A')
     cy.task('updateCiagPlan', 'B79237A')
+    cy.task('stubUpdateInduction', 'B79237A')
     cy.signIn()
   })
 

--- a/server/data/ciagApi/models/updateCiagPlanRequest.ts
+++ b/server/data/ciagApi/models/updateCiagPlanRequest.ts
@@ -15,6 +15,7 @@ import { getValueSafely } from '../../../utils'
 
 export default class UpdateCiagPlanRequest {
   constructor(data: CiagPlan) {
+    this.reference = data.reference
     this.offenderId = data.offenderId
     this.prisonId = data.prisonId
 
@@ -40,7 +41,11 @@ export default class UpdateCiagPlanRequest {
   }
 
   // Properties
+  reference?: string
+
   offenderId: string
+
+  workOnReleaseReference?: string
 
   desireToWork: boolean
 
@@ -65,6 +70,7 @@ export default class UpdateCiagPlanRequest {
   prisonId: string
 
   workExperience?: {
+    reference?: string
     id?: number
     hasWorkedBefore: boolean
     typeOfWorkExperience?: Array<TypeOfWorkExperienceValue>
@@ -78,6 +84,7 @@ export default class UpdateCiagPlanRequest {
     modifiedDateTime: string
 
     workInterests?: {
+      reference?: string
       id?: number
       workInterests: Array<WorkInterestsValue>
       workInterestsOther?: string
@@ -91,6 +98,7 @@ export default class UpdateCiagPlanRequest {
   }
 
   skillsAndInterests?: {
+    reference?: string
     id?: number
     skills: Array<SkillsValue>
     skillsOther?: string
@@ -101,6 +109,7 @@ export default class UpdateCiagPlanRequest {
   }
 
   qualificationsAndTraining?: {
+    qualificationsReference?: string
     id?: number
     educationLevel?: EducationLevelValue
     qualifications?: Array<{
@@ -108,6 +117,8 @@ export default class UpdateCiagPlanRequest {
       grade: string
       level: QualificationLevelValue
     }>
+
+    trainingReference?: string
     additionalTraining: Array<AdditionalTrainingValue>
     additionalTrainingOther?: string
     modifiedBy: string
@@ -115,6 +126,7 @@ export default class UpdateCiagPlanRequest {
   }
 
   inPrisonInterests?: {
+    reference?: string
     id?: number
     inPrisonWork: Array<InPrisonWorkValue>
     inPrisonWorkOther?: string

--- a/server/data/mappers/createOrUpdateInductionDtoMapper.test.ts
+++ b/server/data/mappers/createOrUpdateInductionDtoMapper.test.ts
@@ -1,4 +1,5 @@
 import CiagPlan from '../ciagApi/interfaces/ciagPlan'
+import UpdateCiagPlanRequest from '../ciagApi/models/updateCiagPlanRequest'
 import HopingToGetWorkValue from '../../enums/hopingToGetWorkValue'
 import ReasonToNotGetWorkValue from '../../enums/reasonToNotGetWorkValue'
 import AdditionalTrainingValue from '../../enums/additionalTrainingValue'
@@ -76,6 +77,145 @@ describe('createOrUpdateInductionDtoMapper', () => {
     // Given
     const prisonNumber = 'A1234BC'
     const ciagPlan: CiagPlan = {
+      reference: 'b32c7ad6-86a7-45a9-bd63-4bd7cf1ff46f',
+      offenderId: prisonNumber,
+      workOnReleaseReference: '2f4cfa00-40ae-4859-9f96-d7576f989a95',
+      desireToWork: true,
+      hopingToGetWork: HopingToGetWorkValue.YES,
+      reasonToNotGetWork: undefined,
+      reasonToNotGetWorkOther: undefined,
+      abilityToWork: [AbilityToWorkValue.HEALTH_ISSUES],
+      abilityToWorkOther: undefined,
+
+      // The properties workExperience, skillsAndInterests, qualificationsAndTraining and inPrisonInterests are
+      // fundamentally the difference between a short and long question set CiagPlan
+      workExperience: {
+        reference: '91e8634a-8ddc-40ee-8854-f099e3e0440f',
+        hasWorkedBefore: true,
+        typeOfWorkExperience: [TypeOfWorkExperienceValue.CONSTRUCTION, TypeOfWorkExperienceValue.OTHER],
+        typeOfWorkExperienceOther: 'Retail delivery',
+        workExperience: [
+          {
+            typeOfWorkExperience: TypeOfWorkExperienceValue.CONSTRUCTION,
+            role: 'General labourer',
+            details: 'Groundwork and basic block work and bricklaying',
+          },
+          {
+            typeOfWorkExperience: TypeOfWorkExperienceValue.OTHER,
+            role: 'Milkman',
+            details: 'Self employed franchise operator delivering milk and associated diary products.',
+          },
+        ],
+        workInterests: {
+          reference: 'b01c4344-dbbf-417e-8b90-17d19062dfa6',
+          workInterests: [WorkInterestsValue.BEAUTY, WorkInterestsValue.OTHER],
+          workInterestsOther: 'Film, TV and media',
+          particularJobInterests: [
+            { workInterest: WorkInterestsValue.BEAUTY, role: undefined },
+            { workInterest: WorkInterestsValue.OTHER, role: 'Being a stunt double for Tom Cruise' },
+          ],
+          modifiedBy: 'asmith_gen',
+          modifiedDateTime: '2023-06-19T09:39:44.000Z',
+        },
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      },
+      skillsAndInterests: {
+        reference: '2bb27e5e-2d49-4502-8c08-629099561c8a',
+        personalInterests: [PersonalInterestsValue.DIGITAL, PersonalInterestsValue.OTHER],
+        personalInterestsOther: 'Renewable energy',
+        skills: [SkillsValue.TEAMWORK, SkillsValue.OTHER],
+        skillsOther: 'Tenacity',
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      },
+      qualificationsAndTraining: {
+        qualificationsReference: '17f34868-99c9-40ed-b923-ca273cacc096',
+        trainingReference: '68f47a63-6e4f-4645-80e7-5757be5f6958',
+        additionalTraining: [AdditionalTrainingValue.FIRST_AID_CERTIFICATE, AdditionalTrainingValue.OTHER],
+        additionalTrainingOther: 'Advanced origami',
+        educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
+        qualifications: [
+          { subject: 'Pottery', level: QualificationLevelValue.LEVEL_4, grade: 'C' },
+          { subject: 'Maths', level: QualificationLevelValue.LEVEL_4, grade: 'B' },
+        ],
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      },
+      inPrisonInterests: undefined,
+      createdBy: 'asmith_gen',
+      createdDateTime: '2023-06-19T09:39:44.000Z',
+      modifiedBy: 'asmith_gen',
+      modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      prisonId: 'BXI',
+    }
+    const expected = anUpdateLongQuestionSetInductionDto()
+
+    // When
+    const actual = toCreateOrUpdateInductionDto(ciagPlan)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  it('should map to CreateOrUpdateInductionDto given a short question set UpdateCiagPlanRequest', () => {
+    // Given
+    const prisonNumber = 'A1234BC'
+    const ciagPlan: UpdateCiagPlanRequest = {
+      reference: 'b32c7ad6-86a7-45a9-bd63-4bd7cf1ff46f',
+      offenderId: prisonNumber,
+      workOnReleaseReference: '2f4cfa00-40ae-4859-9f96-d7576f989a95',
+      desireToWork: false,
+      hopingToGetWork: HopingToGetWorkValue.NO,
+      reasonToNotGetWork: [ReasonToNotGetWorkValue.OTHER],
+      reasonToNotGetWorkOther: 'Will be of retirement age at release',
+      abilityToWork: undefined,
+      abilityToWorkOther: undefined,
+      // The properties workExperience, skillsAndInterests, qualificationsAndTraining and inPrisonInterests are
+      // fundamentally the difference between a short and long question set CiagPlan
+      workExperience: undefined,
+      skillsAndInterests: undefined,
+      qualificationsAndTraining: {
+        qualificationsReference: '2f47cae9-9310-4da5-8984-3577be9ce54d',
+        trainingReference: '8ac71798-100e-4652-abbc-5604f231499e',
+        additionalTraining: [AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE, AdditionalTrainingValue.OTHER],
+        additionalTrainingOther: 'Beginners cookery for IT professionals',
+        educationLevel: undefined,
+        qualifications: [
+          { subject: 'English', level: QualificationLevelValue.LEVEL_6, grade: 'B' },
+          { subject: 'Maths', level: QualificationLevelValue.LEVEL_6, grade: 'A*' },
+        ],
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      },
+      inPrisonInterests: {
+        reference: 'fd6df985-2b77-4f64-a860-f37389fa4dd3',
+        inPrisonEducation: [InPrisonEducationValue.FORKLIFT_DRIVING, InPrisonEducationValue.OTHER],
+        inPrisonEducationOther: 'Advanced origami',
+        inPrisonWork: [InPrisonWorkValue.CLEANING_AND_HYGIENE, InPrisonWorkValue.OTHER],
+        inPrisonWorkOther: 'Gardening and grounds keeping',
+        modifiedBy: 'asmith_gen',
+        modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      },
+      createdBy: 'asmith_gen',
+      createdDateTime: '2023-06-19T09:39:44.000Z',
+      modifiedBy: 'asmith_gen',
+      modifiedDateTime: '2023-06-19T09:39:44.000Z',
+      prisonId: 'BXI',
+    }
+    const expected = anUpdateShortQuestionSetInductionDto()
+
+    // When
+    const actual = toCreateOrUpdateInductionDto(ciagPlan)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  it('should map to CreateOrUpdateInductionDto given a long question set UpdateCiagPlanRequest', () => {
+    // Given
+    const prisonNumber = 'A1234BC'
+    const ciagPlan: UpdateCiagPlanRequest = {
       reference: 'b32c7ad6-86a7-45a9-bd63-4bd7cf1ff46f',
       offenderId: prisonNumber,
       workOnReleaseReference: '2f4cfa00-40ae-4859-9f96-d7576f989a95',

--- a/server/data/mappers/createOrUpdateInductionDtoMapper.ts
+++ b/server/data/mappers/createOrUpdateInductionDtoMapper.ts
@@ -1,7 +1,8 @@
 import type { CreateOrUpdateInductionDto } from 'dto'
 import CiagPlan from '../ciagApi/interfaces/ciagPlan'
+import UpdateCiagPlanRequest from '../ciagApi/models/updateCiagPlanRequest'
 
-const toCreateOrUpdateInductionDto = (ciagPlan: CiagPlan): CreateOrUpdateInductionDto => {
+const toCreateOrUpdateInductionDto = (ciagPlan: CiagPlan | UpdateCiagPlanRequest): CreateOrUpdateInductionDto => {
   return {
     reference: ciagPlan.reference,
     prisonId: ciagPlan.prisonId,
@@ -15,7 +16,7 @@ const toCreateOrUpdateInductionDto = (ciagPlan: CiagPlan): CreateOrUpdateInducti
   }
 }
 
-const toCreateOrUpdateWorkOnReleaseDto = (ciagPlan: CiagPlan) => {
+const toCreateOrUpdateWorkOnReleaseDto = (ciagPlan: CiagPlan | UpdateCiagPlanRequest) => {
   return {
     reference: ciagPlan.workOnReleaseReference,
     hopingToWork: ciagPlan.hopingToGetWork,
@@ -25,7 +26,7 @@ const toCreateOrUpdateWorkOnReleaseDto = (ciagPlan: CiagPlan) => {
     affectAbilityToWorkOther: ciagPlan.abilityToWorkOther,
   }
 }
-const toCreateOrUpdatePreviousQualificationsDto = (ciagPlan: CiagPlan) => {
+const toCreateOrUpdatePreviousQualificationsDto = (ciagPlan: CiagPlan | UpdateCiagPlanRequest) => {
   return ciagPlan.qualificationsAndTraining
     ? {
         reference: ciagPlan.qualificationsAndTraining.qualificationsReference,
@@ -40,7 +41,7 @@ const toCreateOrUpdatePreviousQualificationsDto = (ciagPlan: CiagPlan) => {
       }
     : undefined
 }
-const toCreateOrUpdatePreviousTrainingDto = (ciagPlan: CiagPlan) => {
+const toCreateOrUpdatePreviousTrainingDto = (ciagPlan: CiagPlan | UpdateCiagPlanRequest) => {
   return ciagPlan.qualificationsAndTraining
     ? {
         reference: ciagPlan.qualificationsAndTraining.trainingReference,
@@ -50,7 +51,7 @@ const toCreateOrUpdatePreviousTrainingDto = (ciagPlan: CiagPlan) => {
     : undefined
 }
 
-const toCreateOrUpdatePreviousWorkExperiencesDto = (ciagPlan: CiagPlan) => {
+const toCreateOrUpdatePreviousWorkExperiencesDto = (ciagPlan: CiagPlan | UpdateCiagPlanRequest) => {
   return ciagPlan.workExperience
     ? {
         reference: ciagPlan.workExperience.reference,
@@ -69,7 +70,7 @@ const toCreateOrUpdatePreviousWorkExperiencesDto = (ciagPlan: CiagPlan) => {
       }
     : undefined
 }
-const toCreateOrUpdateInPrisonInterestsDto = (ciagPlan: CiagPlan) => {
+const toCreateOrUpdateInPrisonInterestsDto = (ciagPlan: CiagPlan | UpdateCiagPlanRequest) => {
   return ciagPlan.inPrisonInterests
     ? {
         reference: ciagPlan.inPrisonInterests.reference,
@@ -89,7 +90,7 @@ const toCreateOrUpdateInPrisonInterestsDto = (ciagPlan: CiagPlan) => {
       }
     : undefined
 }
-const toCreateOrUpdatePersonalSkillsAndInterestsDto = (ciagPlan: CiagPlan) => {
+const toCreateOrUpdatePersonalSkillsAndInterestsDto = (ciagPlan: CiagPlan | UpdateCiagPlanRequest) => {
   return ciagPlan.skillsAndInterests
     ? {
         reference: ciagPlan.skillsAndInterests.reference,
@@ -108,7 +109,7 @@ const toCreateOrUpdatePersonalSkillsAndInterestsDto = (ciagPlan: CiagPlan) => {
       }
     : undefined
 }
-const toCreateOrUpdateFutureWorkInterestsDto = (ciagPlan: CiagPlan) => {
+const toCreateOrUpdateFutureWorkInterestsDto = (ciagPlan: CiagPlan | UpdateCiagPlanRequest) => {
   return ciagPlan.workExperience?.workInterests
     ? {
         reference: ciagPlan.workExperience.workInterests.reference,

--- a/server/routes/createPlan/abilityToWork/index.ts
+++ b/server/routes/createPlan/abilityToWork/index.ts
@@ -7,7 +7,7 @@ import AbilityToWorkController from './abilityToWorkController'
 import checkSessionPageData from '../../../middleware/checkSessionPageData'
 
 export default (router: Router, services: Services) => {
-  const controller = new AbilityToWorkController(services.ciagService)
+  const controller = new AbilityToWorkController(services.ciagService, services.inductionService)
 
   router.get(
     '/plan/create/:id/ability-to-work/:mode',

--- a/server/routes/createPlan/checkYourAnswers/checkYourAnswersController.test.ts
+++ b/server/routes/createPlan/checkYourAnswers/checkYourAnswersController.test.ts
@@ -38,6 +38,7 @@ describe('CheckYourAnswersController', () => {
 
   const mockInductionService: any = {
     createInduction: jest.fn(),
+    updateInduction: jest.fn(),
   }
 
   let learningPlanUrl: string
@@ -160,6 +161,21 @@ describe('CheckYourAnswersController', () => {
       // Then
       expect(mockInductionService.createInduction).toHaveBeenCalledTimes(1)
       expect(res.redirect).toHaveBeenCalledWith('http://plp-ui-url/plan/A1234BC/induction-created')
+    })
+
+    it('On success - NEW - Calls PLP API update', async () => {
+      // Given
+      config.featureToggles.useNewInductionApiEnabled = true
+      req.context.plan = { hopingToGetWork: HopingToGetWorkValue.NOT_SURE, desireToWork: false }
+      setSessionData(req, ['isUpdateFlow', id], true)
+      mockInductionService.updateInduction.mockReturnValue({})
+
+      // When
+      await controller.post(req, res, next)
+
+      // Then
+      expect(mockInductionService.updateInduction).toHaveBeenCalledTimes(1)
+      expect(res.redirect).toHaveBeenCalledWith('http://plp-ui-url/plan/A1234BC/view/work-and-interests')
     })
   })
 })


### PR DESCRIPTION
This PR is the first in a series that modify each controller to call the new `/inductions` API, rather than the legacy CIAG one, when updating an Induction